### PR TITLE
fix(volunteer-form): merge PDF reference form into volunteer application (#21)

### DIFF
--- a/src/app/(main)/apply/volunteer/page.tsx
+++ b/src/app/(main)/apply/volunteer/page.tsx
@@ -10,6 +10,13 @@ export const metadata: Metadata = {
 export default function VolunteerApplicationPage() {
   return (
     <main className="max-w-3xl mx-auto px-4 py-12">
+      {/* Application-only banner */}
+      <div className="bg-amber-50 border border-amber-300 rounded-lg px-5 py-3 mb-6 text-center">
+        <p className="text-amber-800 font-semibold text-sm tracking-wide">
+          ** THIS IS A VOLUNTEER APPLICATION ONLY **
+        </p>
+      </div>
+
       <h1 className="text-4xl font-bold text-gray-900 mb-2">Volunteer Application</h1>
       <p className="text-lg text-teal-700 font-medium mb-2">
         Thank you for your interest in volunteering with RMGDRI!

--- a/src/app/api/forms/volunteer/submit/route.ts
+++ b/src/app/api/forms/volunteer/submit/route.ts
@@ -1,6 +1,7 @@
 /* ------------------------------------------------------------------ *
  *  POST /api/forms/volunteer/submit                                    *
  *  Volunteer Application — server-side handler                         *
+ *  Merged: current draft + PDF reference form (Issue #21)             *
  * ------------------------------------------------------------------ */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -20,6 +21,16 @@ function isRateLimited(ip: string): boolean {
   hits.set(ip, log);
   return log.length > RATE_LIMIT;
 }
+
+/** Keys whose required check is "array with ≥1 element" */
+const ARRAY_REQUIRED_KEYS = new Set(["roles"]);
+
+/** Keys whose required check is "Yes" radio acceptance */
+const ACCEPTANCE_RADIO_KEYS = new Set([
+  "certify_over_18",
+  "agree_to_policies",
+  "accept_code_conduct_agreement",
+]);
 
 /* ── Handler ── */
 export async function POST(req: NextRequest) {
@@ -53,29 +64,33 @@ export async function POST(req: NextRequest) {
   }
 
   /* 4. Required-field enforcement (raw stage) */
-  const requiredFields = VOLUNTEER_FIELD_MAP.filter((f) => f.required);
+  // Skip "info" type fields — they are static text blocks, not form inputs
+  const requiredFields = VOLUNTEER_FIELD_MAP.filter((f) => f.required && f.type !== "info");
   const missing: string[] = [];
   const labels: Record<string, string> = {};
 
   for (const f of requiredFields) {
-    if (f.key === "roles") {
-      // Special handling: roles must be an array with ≥ 1 element
-      const roles = body.roles;
-      if (!Array.isArray(roles) || roles.length === 0) {
-        missing.push("roles");
-        labels["roles"] = f.label;
+    /* Array fields (roles, checkbox-group) must have ≥1 element */
+    if (ARRAY_REQUIRED_KEYS.has(f.key) || f.type === "checkbox-group") {
+      const val = body[f.key];
+      if (!Array.isArray(val) || val.length === 0) {
+        missing.push(f.key);
+        labels[f.key] = f.label;
       }
       continue;
     }
-    if (f.key === "certify_info_true") {
-      // Must be truthy
-      const val = body.certify_info_true;
-      if (val !== true && val !== "true" && val !== "Yes") {
-        missing.push("certify_info_true");
-        labels["certify_info_true"] = f.label;
+
+    /* Acceptance radio fields — must be "Yes" */
+    if (ACCEPTANCE_RADIO_KEYS.has(f.key)) {
+      const val = body[f.key];
+      if (val !== "Yes") {
+        missing.push(f.key);
+        labels[f.key] = f.label;
       }
       continue;
     }
+
+    /* Standard string fields */
     const val = body[f.key];
     if (val === undefined || val === null || (typeof val === "string" && val.trim() === "")) {
       missing.push(f.key);
@@ -92,7 +107,7 @@ export async function POST(req: NextRequest) {
 
   /* 5. Validate role IDs are from canonical set */
   if (Array.isArray(body.roles)) {
-    const invalid = (body.roles as string[]).filter((r) => !VOLUNTEER_ROLE_IDS.includes(r as any));
+    const invalid = (body.roles as string[]).filter((r) => !VOLUNTEER_ROLE_IDS.includes(r as never));
     if (invalid.length > 0) {
       return NextResponse.json(
         { ok: false, error: "Invalid role IDs", invalid, stage: "role-validation" },

--- a/src/components/forms/VolunteerForm.tsx
+++ b/src/components/forms/VolunteerForm.tsx
@@ -8,7 +8,20 @@ import {
 } from "@/lib/forms/volunteer/field-map";
 import { VOLUNTEER_ROLES } from "@/lib/forms/volunteer/labels";
 
-/* ── Field input renderer ── */
+/* ──────────────────────────────────────────────────────────────────
+ * InfoBlock — static text block renderer (type "info")
+ * ────────────────────────────────────────────────────────────────── */
+function InfoBlock({ text }: { text: string }) {
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-lg px-5 py-4 text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+      {text}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * FieldInput — renders the appropriate input for each field type
+ * ────────────────────────────────────────────────────────────────── */
 function FieldInput({
   field,
   value,
@@ -52,6 +65,34 @@ function FieldInput({
     );
   }
 
+  /* ── checkbox-group (generic multi-select with custom options) ── */
+  if (field.type === "checkbox-group" && field.options) {
+    const selected = Array.isArray(value) ? value : [];
+    return (
+      <div className="flex flex-wrap gap-3">
+        {field.options.map((opt) => (
+          <label
+            key={opt}
+            className="flex items-center gap-2 text-gray-700 text-sm cursor-pointer hover:bg-teal-50 rounded-lg px-3 py-2 transition-colors border border-gray-200"
+          >
+            <input
+              type="checkbox"
+              checked={selected.includes(opt)}
+              onChange={() => {
+                const next = selected.includes(opt)
+                  ? selected.filter((v) => v !== opt)
+                  : [...selected, opt];
+                onChange(field.key, next);
+              }}
+              className="accent-teal-600 w-4 h-4"
+            />
+            {opt}
+          </label>
+        ))}
+      </div>
+    );
+  }
+
   /* ── checkbox (single boolean) ── */
   if (field.type === "checkbox") {
     return (
@@ -88,6 +129,24 @@ function FieldInput({
     );
   }
 
+  /* ── select dropdown ── */
+  if (field.type === "select" && field.options) {
+    return (
+      <select
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => onChange(field.key, e.target.value)}
+        className={`${baseClass} ${errorBorder} bg-white`}
+      >
+        <option value="">— select —</option>
+        {field.options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
   /* ── textarea ── */
   if (field.type === "textarea") {
     return (
@@ -113,11 +172,14 @@ function FieldInput({
   );
 }
 
-/* ── Main form ── */
+/* ──────────────────────────────────────────────────────────────────
+ * Main VolunteerForm component
+ * ────────────────────────────────────────────────────────────────── */
 export default function VolunteerForm() {
   const [formData, setFormData] = useState<Record<string, string | string[] | boolean>>(() => {
     const init: Record<string, string | string[] | boolean> = {};
     for (const f of VOLUNTEER_FIELD_MAP) {
+      if (f.type === "info") continue; // static blocks have no form state
       if (f.type === "roles" || f.type === "checkbox-group") init[f.key] = [];
       else if (f.type === "checkbox") init[f.key] = false;
       else init[f.key] = "";
@@ -144,12 +206,12 @@ export default function VolunteerForm() {
       setErrorMessage("");
       setFieldErrors(new Set());
 
-      /* Client-side required check */
+      /* Client-side required check — skip "info" type fields */
       const missing = new Set<string>();
       for (const f of VOLUNTEER_FIELD_MAP) {
-        if (!f.required) continue;
+        if (!f.required || f.type === "info") continue;
         const val = formData[f.key];
-        if (f.type === "roles") {
+        if (f.type === "roles" || f.type === "checkbox-group") {
           if (!Array.isArray(val) || val.length === 0) missing.add(f.key);
         } else if (f.type === "checkbox") {
           if (val !== true && val !== "true") missing.add(f.key);
@@ -160,7 +222,6 @@ export default function VolunteerForm() {
       if (missing.size > 0) {
         setFieldErrors(missing);
         setErrorMessage("Please complete all required fields.");
-        // Scroll to first error
         const firstKey = [...missing][0];
         const el = document.getElementById(`field-${firstKey}`);
         el?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -176,7 +237,6 @@ export default function VolunteerForm() {
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok) {
-          /* Highlight server-reported missing fields */
           if (Array.isArray(json.missing)) {
             setFieldErrors(new Set(json.missing));
           }
@@ -185,7 +245,9 @@ export default function VolunteerForm() {
         setStatus("success");
       } catch (err: unknown) {
         setStatus("error");
-        setErrorMessage(err instanceof Error ? err.message : "Submission failed. Please try again.");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Submission failed. Please try again.",
+        );
       }
     },
     [formData],
@@ -198,7 +260,8 @@ export default function VolunteerForm() {
         <div className="text-4xl mb-4">&#10003;</div>
         <h2 className="text-2xl font-bold text-green-800 mb-2">Thank You!</h2>
         <p className="text-green-700">
-          Your volunteer application has been received. Our team will review it and get back to you soon.
+          Your volunteer application has been received. Our team will review it and get back to you
+          soon.
         </p>
       </div>
     );
@@ -226,8 +289,18 @@ export default function VolunteerForm() {
             </legend>
 
             {fields.map((field) => {
+              /* ── info / text block — no input, no label ── */
+              if (field.type === "info") {
+                return (
+                  <div key={field.key}>
+                    {field.textBlock && <InfoBlock text={field.textBlock} />}
+                  </div>
+                );
+              }
+
               const hasError = fieldErrors.has(field.key);
-              /* Single-checkbox fields get inline label from FieldInput */
+
+              /* ── single checkbox — inline label rendered by FieldInput ── */
               if (field.type === "checkbox") {
                 return (
                   <div key={field.key} id={`field-${field.key}`}>
@@ -243,15 +316,22 @@ export default function VolunteerForm() {
                   </div>
                 );
               }
+
+              /* ── all other field types ── */
               return (
                 <div key={field.key} id={`field-${field.key}`} className="space-y-1">
                   <label className="block text-sm font-medium text-gray-700">
                     {field.label}
                     {field.required && <span className="text-red-500 ml-1">*</span>}
                   </label>
+                  {field.hint && (
+                    <p className="text-xs text-gray-500 italic mb-1">{field.hint}</p>
+                  )}
                   <FieldInput
                     field={field}
-                    value={formData[field.key] ?? ""}
+                    value={formData[field.key] ?? (
+                      field.type === "roles" || field.type === "checkbox-group" ? [] : ""
+                    )}
                     onChange={handleChange}
                     error={hasError}
                   />

--- a/src/lib/forms/volunteer/field-map.ts
+++ b/src/lib/forms/volunteer/field-map.ts
@@ -1,48 +1,476 @@
 /* ------------------------------------------------------------------ *
  *  Volunteer Application — field map (drives form UI + validation)     *
- *  Derived from Lori's canonical volunteer roles + PDF reference        *
+ *  Merged: current draft + PDF reference form (Issue #21)              *
  * ------------------------------------------------------------------ */
 
 export interface FieldDef {
   key: string;
   label: string;
   required: boolean;
-  type: "text" | "textarea" | "select" | "radio" | "email" | "tel" | "checkbox-group" | "checkbox" | "roles";
+  type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "radio"
+    | "email"
+    | "tel"
+    | "checkbox-group"
+    | "checkbox"
+    | "roles"
+    | "info";
   section: string;
   options?: string[];
   placeholder?: string;
+  /** Short explanatory text displayed in italic below the label, before the input. */
+  hint?: string;
+  /** Longer static content displayed as a styled text block (no input rendered). */
+  textBlock?: string;
 }
 
 export const VOLUNTEER_FIELD_MAP: FieldDef[] = [
-  /* ── Section 1: Applicant Information ── */
-  { key: "applicant_first_name", label: "First Name", required: true, type: "text", section: "Applicant Information" },
-  { key: "applicant_last_name",  label: "Last Name",  required: true, type: "text", section: "Applicant Information" },
-  { key: "email",                label: "Email",       required: true, type: "email", section: "Applicant Information", placeholder: "you@example.com" },
-  { key: "phone_primary",       label: "Phone",       required: true, type: "tel",   section: "Applicant Information" },
-  { key: "city",                 label: "City",        required: true, type: "text",  section: "Applicant Information" },
-  { key: "state",                label: "State",       required: true, type: "text",  section: "Applicant Information", placeholder: "e.g. CO" },
 
-  /* ── Section 2: Availability ── */
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 1: Applicant Information
+   * ═══════════════════════════════════════════════════════════════ */
+  { key: "applicant_first_name", label: "First Name",    required: true,  type: "text",  section: "Applicant Information" },
+  { key: "applicant_last_name",  label: "Last Name",     required: true,  type: "text",  section: "Applicant Information" },
+  { key: "address_street",       label: "Street Address", required: true,  type: "text",  section: "Applicant Information", placeholder: "123 Main St" },
+  { key: "address_street2",      label: "Street Line 2", required: false, type: "text",  section: "Applicant Information", placeholder: "Apt, Suite, etc. (optional)" },
+  { key: "address_city",         label: "City",          required: true,  type: "text",  section: "Applicant Information" },
+  { key: "address_state",        label: "State",         required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. CO" },
+  { key: "address_zip",          label: "Zip Code",      required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. 80202" },
+  { key: "email",                label: "Email",         required: true,  type: "email", section: "Applicant Information", placeholder: "you@example.com" },
+  { key: "phone_primary",        label: "Home Phone",    required: true,  type: "tel",   section: "Applicant Information" },
+  { key: "phone_mobile",         label: "Mobile Phone",  required: true,  type: "tel",   section: "Applicant Information" },
+  { key: "age",                  label: "Age",           required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. 28" },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 2: Employment & Insurance
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "employment_status",
+    label: "I work",
+    required: true,
+    type: "radio",
+    section: "Employment & Insurance",
+    options: ["Full Time Job", "Part Time Job", "Other"],
+  },
+  {
+    key: "hours_per_week",
+    label: "I can realistically help ___ hours per week",
+    required: true,
+    type: "select",
+    section: "Employment & Insurance",
+    options: ["1-2", "3-5", "6-10", "11-15", "16-20", "20+"],
+  },
+  {
+    key: "has_health_insurance",
+    label: "I have health insurance",
+    required: true,
+    type: "radio",
+    section: "Employment & Insurance",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "insurance_company",
+    label: "If you have health insurance, please note insurance company",
+    required: false,
+    type: "text",
+    section: "Employment & Insurance",
+    hint: "If you do not have health insurance coverage, please understand that all expenses from possible injury will be paid for by you personally and not by RMGDRI.",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 3: Background Check
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "investigated_by_animal_control",
+    label: "Have you ever been investigated by Animal Control?",
+    required: true,
+    type: "radio",
+    section: "Background Check",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "convicted_animal_abuse",
+    label: "Have you been convicted of any animal abuse law?",
+    required: true,
+    type: "radio",
+    section: "Background Check",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "animal_abuse_explanation",
+    label: "If yes, please explain.",
+    required: false,
+    type: "textarea",
+    section: "Background Check",
+  },
+  {
+    key: "worked_with_shelter",
+    label: "Have you worked/volunteered with a humane society, shelter, or animal care?",
+    required: true,
+    type: "radio",
+    section: "Background Check",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "shelter_involvement_current",
+    label: "Is your involvement with the organization(s) current?",
+    required: false,
+    type: "radio",
+    section: "Background Check",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "volunteered_with_rmgdri",
+    label: "Have you volunteered with Rocky Mountain Great Dane Rescue in the past? (adoption, volunteer, foster, surrender, etc)",
+    required: true,
+    type: "radio",
+    section: "Background Check",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "prior_organizations",
+    label: "If yes, please list organization(s)",
+    required: false,
+    type: "text",
+    section: "Background Check",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 4: Experience & Skills
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "identify_great_dane",
+    label: "Do you feel competent to identify a Great Dane, its color and markings, whether it is a purebred or mixed breed Dane?",
+    required: true,
+    type: "radio",
+    section: "Experience & Skills",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "trained_evaluating_temperament",
+    label: "Have you been trained in evaluating a dog\u2019s personality and/or temperament?",
+    required: true,
+    type: "radio",
+    section: "Experience & Skills",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "completed_obedience_course",
+    label: "Have you completed obedience course(s), competed in dog sport or been involved in any public dog activities?",
+    required: true,
+    type: "radio",
+    section: "Experience & Skills",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "obedience_course_details",
+    label: "If yes, please describe.",
+    required: false,
+    type: "textarea",
+    section: "Experience & Skills",
+  },
+  {
+    key: "dog_experience",
+    label: "Describe your experience with dogs",
+    required: true,
+    type: "textarea",
+    section: "Experience & Skills",
+  },
+  {
+    key: "giant_breed_experience",
+    label: "Do you have experience with giant breed dogs?",
+    required: true,
+    type: "radio",
+    section: "Experience & Skills",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "giant_breed_details",
+    label: "If yes, please describe your giant breed experience",
+    required: false,
+    type: "textarea",
+    section: "Experience & Skills",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 5: Availability
+   * ═══════════════════════════════════════════════════════════════ */
   { key: "availability_weekdays", label: "Available on weekdays?",  required: true, type: "radio", section: "Availability", options: ["Yes", "No"] },
   { key: "availability_weekends", label: "Available on weekends?",  required: true, type: "radio", section: "Availability", options: ["Yes", "No"] },
   { key: "hours_per_month",       label: "How many hours per month can you realistically volunteer?", required: true, type: "text", section: "Availability", placeholder: "e.g. 10" },
 
-  /* ── Section 3: Volunteer Roles ── */
-  // Rendered by the form component using VOLUNTEER_ROLES from labels.ts
-  // The "roles" type signals the form to render the canonical role checkboxes
-  { key: "roles", label: "Which volunteer roles interest you? (select at least one)", required: true, type: "roles", section: "Volunteer Roles" },
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 6: Volunteer Roles
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "roles",
+    label: "Which volunteer roles interest you? (select at least one)",
+    required: true,
+    type: "roles",
+    section: "Volunteer Roles",
+  },
 
-  /* ── Section 4: Experience ── */
-  { key: "dog_experience",          label: "Describe your experience with dogs",                          required: true,  type: "textarea", section: "Experience" },
-  { key: "giant_breed_experience",  label: "Do you have experience with giant breed dogs?",               required: true,  type: "radio",    section: "Experience", options: ["Yes", "No"] },
-  { key: "giant_breed_details",     label: "If yes, please describe your giant breed experience",         required: false, type: "textarea", section: "Experience" },
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 7: About Yourself
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "occupation",
+    label: "What do you do for a living?",
+    required: false,
+    type: "textarea",
+    section: "About Yourself",
+  },
+  {
+    key: "has_color_copier",
+    label: "Do you have access to a color copier?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "other_experience_education",
+    label: "Do you have experience/education in a field other than your current profession?",
+    required: false,
+    type: "textarea",
+    section: "About Yourself",
+  },
+  {
+    key: "company_matching_program",
+    label: "Does your company have a charitable employee matching program?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "promo_product_contacts",
+    label: "Do you have any contacts with promotional product companies?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "auction_donor_contacts",
+    label: "Do you know any business owners, artists, etc, who may be willing to donate something for our silent auction fundraisers?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "website_design_experience",
+    label: "Do you have experience with website design or trafficking?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "media_connections",
+    label: "Do you have any connections with the media (print, TV, Internet)?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "writing_experience",
+    label: "Do you have any experience writing? Would you be interested in helping with our newsletter?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "venue_connections",
+    label: "Do you have any connections with large venues that may be willing to host upcoming events?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "animal_rights_background",
+    label: "Do you have any background in animal rights?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "dog_training_experience",
+    label: "Do you have any dog training experience?",
+    required: true,
+    type: "radio",
+    section: "About Yourself",
+    options: ["Yes", "No"],
+  },
 
-  /* ── Section 5: Consent & Signature ── */
-  { key: "certify_info_true",      label: "I certify that the information provided in this application is truthful and complete.", required: true, type: "checkbox", section: "Consent & Signature" },
-  { key: "electronic_signature",   label: "Electronic Signature (type your full name)",                    required: true, type: "text",     section: "Consent & Signature", placeholder: "Your full legal name" },
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 8: Great Dane Transportation
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "transport_distance",
+    label: "If you can transport a Great Dane, how far are you willing to travel?",
+    required: false,
+    type: "radio",
+    section: "Great Dane Transportation",
+    options: ["0 - 10 miles", "11 - 25 miles", "26 - 50 miles", "Over 50 miles"],
+  },
+  {
+    key: "transport_vehicle_type",
+    label: "What type of vehicle would you use to transport a Great Dane?",
+    required: false,
+    type: "checkbox-group",
+    section: "Great Dane Transportation",
+    options: ["Car", "SUV", "Other"],
+  },
+  {
+    key: "transport_vehicle_other",
+    label: "If you answered \u2018Other\u2019 above please elaborate on the type of vehicle you own.",
+    required: false,
+    type: "textarea",
+    section: "Great Dane Transportation",
+  },
+  {
+    key: "sign_code_of_ethics",
+    label: "Are you willing to sign and abide by the Rocky Mountain Great Dane Rescue, Inc. Code of Ethics?",
+    required: false,
+    type: "radio",
+    section: "Great Dane Transportation",
+    options: ["Yes", "No"],
+  },
 
-  /* ── Optional ── */
-  { key: "additional_notes", label: "Anything else you'd like us to know?", required: false, type: "textarea", section: "Additional Notes" },
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 9: References
+   * ═══════════════════════════════════════════════════════════════ */
+  { key: "reference1_name",  label: "Reference 1: Name",  required: true, type: "text", section: "References" },
+  { key: "reference1_phone", label: "Reference 1: Phone", required: true, type: "tel",  section: "References" },
+  { key: "reference2_name",  label: "Reference 2: Name",  required: true, type: "text", section: "References" },
+  { key: "reference2_phone", label: "Reference 2: Phone", required: true, type: "tel",  section: "References" },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 10: Volunteer Liability Release
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "_liability_intro",
+    label: "",
+    required: false,
+    type: "info",
+    section: "Volunteer Liability Release",
+    textBlock:
+      "Volunteers are an important part of RMGDRI and we welcome those who wish to participate in our programs.\n\nSteps to becoming a volunteer at RMGDRI:\n1. You must have an application on file and have attended any RMGDRI sanctioned event.\n2. Anyone that will be volunteering must willingly sign this form.",
+  },
+  {
+    key: "certify_over_18",
+    label: "I certify that as of today\u2019s date, I am over 18 years of age",
+    required: true,
+    type: "radio",
+    section: "Volunteer Liability Release",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "guardian_present_if_minor",
+    label: "If between 16\u201318 years old: I certify that my guardian will be with me at all times while I am volunteering for RMGDRI",
+    required: false,
+    type: "radio",
+    section: "Volunteer Liability Release",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "guardian_name",
+    label: "Guardian\u2019s Name",
+    required: false,
+    type: "text",
+    section: "Volunteer Liability Release",
+    placeholder: "First Last",
+  },
+  {
+    key: "guardian_phone",
+    label: "Guardian\u2019s Phone",
+    required: false,
+    type: "tel",
+    section: "Volunteer Liability Release",
+  },
+  {
+    key: "guardian_email",
+    label: "Guardian\u2019s Email Address",
+    required: false,
+    type: "email",
+    section: "Volunteer Liability Release",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 11: Waiver & Agreement
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "_waiver_text",
+    label: "",
+    required: false,
+    type: "info",
+    section: "Waiver & Agreement",
+    textBlock:
+      "I also understand that behavior of domestic animals is at times unpredictable and that some domestic animals are capable of inflicting property damage, serious personal injury and even death. I am well aware of the risk of handling domestic animals, and with such understanding, I hereby waive, release and forever discharge RMGDRI and its employees/volunteers, agents or trainers from any and all claims (whether present or future) arising out of the participation in the Volunteer Program.",
+  },
+  {
+    key: "agree_to_policies",
+    label: "If I am accepted into the volunteer program, I agree to adhere to RMGDRI procedures and policies",
+    required: true,
+    type: "radio",
+    section: "Waiver & Agreement",
+    options: ["Yes", "No"],
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 12: Code of Conduct
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "_code_of_conduct_text",
+    label: "",
+    required: false,
+    type: "info",
+    section: "Code of Conduct",
+    textBlock:
+      "RESPECT AND COURTESY\nAll members are expected to treat other members, fosters, adopters, donors, volunteers, and the general public with respect and courtesy. Disagreements happen, but rudeness, personal attacks, and disrespectful language are never acceptable.\n\nPRIVACY\nMembers must respect the privacy of others. Do not share personal information about individuals (addresses, phone numbers, financial details, medical information) without explicit consent.\n\nDISRUPTIVE POSTS\nPosts that disrupt the harmony of the group, create unnecessary drama, or spread negativity are prohibited. This includes inflammatory statements, excessive venting, or content designed to provoke others.\n\nPROBLEMS AND ABUSE REPORTING\nIf you witness misconduct, abuse, or a violation of these standards, report it to leadership immediately. Do not attempt to handle the situation publicly on social media or within group forums.\n\nBASELESS ALLEGATIONS\nMaking baseless or unsubstantiated allegations against individuals, organizations, or RMGDRI itself is a serious violation. If you have concerns, bring them through proper channels.\n\nINVESTIGATION\nAll reported violations will be investigated fairly and confidentially. Members found in violation of the Code of Conduct may be removed from volunteer service.\n\nPlease contact Tracy Corwin (tlcorwin@rmgreatdane.org) with any misconduct issues.",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 13: Volunteer Agreement
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "_volunteer_agreement_text",
+    label: "",
+    required: false,
+    type: "info",
+    section: "Volunteer Agreement",
+    textBlock:
+      "I, in consideration of being accepted as a volunteer for Rocky Mountain Great Dane Rescue, Inc. (RMGDRI), agree to abide by all the rules and regulations set forth by RMGDRI and to conduct myself in a professional and courteous manner at all times while volunteering.\n\nI understand that RMGDRI reserves the right to reassign or dismiss any volunteer for just cause, including but not limited to: failure to follow RMGDRI policies and procedures, conduct unbecoming a volunteer, or any action deemed detrimental to RMGDRI, its animals, or its reputation.\n\nI agree to maintain strict confidentiality regarding all adopter, foster, donor, and applicant information I may encounter during my volunteer service. I understand that unauthorized disclosure of confidential information may result in immediate dismissal and potential legal action.\n\nI agree to handle all animals in my care with compassion, patience, and in accordance with RMGDRI\u2019s animal handling guidelines. I will immediately report any animal health concerns, injuries, or behavioral issues to the appropriate RMGDRI coordinator.\n\nI understand that RMGDRI may use photographs or videos taken during volunteer activities for promotional and educational purposes. I grant RMGDRI permission to use my likeness in such materials without compensation.",
+  },
+
+  /* ═══════════════════════════════════════════════════════════════
+   * Section 14: Final Acceptance & Signature
+   * ═══════════════════════════════════════════════════════════════ */
+  {
+    key: "accept_code_conduct_agreement",
+    label: "I accept the Code of Conduct, Volunteer Agreement and Photography Release. Consider acceptance as my signature",
+    required: true,
+    type: "radio",
+    section: "Final Acceptance & Signature",
+    options: ["Yes", "No"],
+  },
+  {
+    key: "electronic_signature",
+    label: "Electronic Signature (type your full name)",
+    required: true,
+    type: "text",
+    section: "Final Acceptance & Signature",
+    placeholder: "Your full legal name",
+  },
 ];
 
 /** Derive unique ordered section names from the field map. */

--- a/src/lib/forms/volunteer/schema.ts
+++ b/src/lib/forms/volunteer/schema.ts
@@ -2,6 +2,7 @@
  *  Volunteer Application — Zod schema                                  *
  *  passthrough + partial keeps forward-compatible with field-map       *
  *  additions (Lori can iterate without breaking validation).           *
+ *  Merged: current draft + PDF reference form (Issue #21)             *
  * ------------------------------------------------------------------ */
 
 import { z } from "zod";
@@ -11,33 +12,90 @@ const sOpt = () => z.string().trim().optional().default("");
 
 export const volunteerSchema = z
   .object({
-    /* ── Applicant Information ── */
+    /* ── Section 1: Applicant Information ── */
     applicant_first_name: s(),
     applicant_last_name:  s(),
+    address_street:       s(),
+    address_street2:      sOpt(),
+    address_city:         s(),
+    address_state:        s(),
+    address_zip:          s(),
     email:                z.string().trim().email("Invalid email address"),
     phone_primary:        s(),
-    city:                 s(),
-    state:                s(),
+    phone_mobile:         s(),
+    age:                  s(),
 
-    /* ── Availability ── */
+    /* ── Section 2: Employment & Insurance ── */
+    employment_status:    s(),
+    hours_per_week:       s(),
+    has_health_insurance: s(),
+    insurance_company:    sOpt(),
+
+    /* ── Section 3: Background Check ── */
+    investigated_by_animal_control: s(),
+    convicted_animal_abuse:         s(),
+    animal_abuse_explanation:       sOpt(),
+    worked_with_shelter:            s(),
+    shelter_involvement_current:    sOpt(),
+    volunteered_with_rmgdri:        s(),
+    prior_organizations:            sOpt(),
+
+    /* ── Section 4: Experience & Skills ── */
+    identify_great_dane:            s(),
+    trained_evaluating_temperament: s(),
+    completed_obedience_course:     s(),
+    obedience_course_details:       sOpt(),
+    dog_experience:                 s(),
+    giant_breed_experience:         s(),
+    giant_breed_details:            sOpt(),
+
+    /* ── Section 5: Availability ── */
     availability_weekdays: s(),
     availability_weekends: s(),
     hours_per_month:       s(),
 
-    /* ── Volunteer Roles ── */
+    /* ── Section 6: Volunteer Roles ── */
     roles: z.array(z.string()).min(1, "At least one volunteer role is required"),
 
-    /* ── Experience ── */
-    dog_experience:         s(),
-    giant_breed_experience: s(),
-    giant_breed_details:    sOpt(),
+    /* ── Section 7: About Yourself ── */
+    occupation:                  sOpt(),
+    has_color_copier:            s(),
+    other_experience_education:  sOpt(),
+    company_matching_program:    s(),
+    promo_product_contacts:      s(),
+    auction_donor_contacts:      s(),
+    website_design_experience:   s(),
+    media_connections:           s(),
+    writing_experience:          s(),
+    venue_connections:           s(),
+    animal_rights_background:    s(),
+    dog_training_experience:     s(),
 
-    /* ── Consent & Signature ── */
-    certify_info_true:    z.union([z.literal(true), z.literal("true"), z.literal("Yes")]),
-    electronic_signature: s(),
+    /* ── Section 8: Great Dane Transportation ── */
+    transport_distance:      sOpt(),
+    transport_vehicle_type:  z.array(z.string()).optional().default([]),
+    transport_vehicle_other: sOpt(),
+    sign_code_of_ethics:     sOpt(),
 
-    /* ── Optional ── */
-    additional_notes: sOpt(),
+    /* ── Section 9: References ── */
+    reference1_name:  s(),
+    reference1_phone: s(),
+    reference2_name:  s(),
+    reference2_phone: s(),
+
+    /* ── Section 10: Volunteer Liability Release ── */
+    certify_over_18:            s(),
+    guardian_present_if_minor:  sOpt(),
+    guardian_name:              sOpt(),
+    guardian_phone:             sOpt(),
+    guardian_email:             sOpt(),
+
+    /* ── Section 11: Waiver & Agreement ── */
+    agree_to_policies: s(),
+
+    /* ── Section 14: Final Acceptance & Signature ── */
+    accept_code_conduct_agreement: s(),
+    electronic_signature:          s(),
   })
   .passthrough()
   .partial();


### PR DESCRIPTION
## Summary

Closes #21. Merges the current volunteer application draft with the RMGDRI PDF reference form, expanding the form from ~15 fields across 5 sections to a full 14-section application.

### What changed

**Kept from current draft (as-is):**
- Availability (weekdays, weekends, hours per month)
- Volunteer Roles (16 canonical checkbox roles)
- Experience (dog experience, giant breed fields)

**New sections from PDF:**
- Applicant Information expanded (street address, city, state, zip, home phone, mobile phone, age)
- Employment & Insurance (employment status radio, hours/week select dropdown, health insurance, insurance company)
- Background Check (Animal Control, animal abuse conviction, shelter/humane society work, RMGDRI history)
- Experience & Skills (Great Dane ID, temperament evaluation, obedience courses merged with existing experience fields)
- About Yourself (12 Yes/No questions about skills, contacts, and capabilities)
- Great Dane Transportation (distance willing to travel, vehicle type checkbox-group, Code of Ethics)
- References (2 references with name + phone)
- Volunteer Liability Release (age certification, guardian fields for minors)
- Waiver & Agreement (liability waiver text block + policy agreement radio)
- Code of Conduct (full text block — read-only info display)
- Volunteer Agreement (full text block — read-only info display)
- Final Acceptance & Signature (acceptance radio + electronic signature)

**Omitted per spec:** "Please rank the Volunteer Opportunities below" section (1-5 rankings).

### Technical changes

| File | Change |
|------|--------|
| `field-map.ts` | Added `hint`, `textBlock`, `info` type to `FieldDef`; full 14-section field array |
| `schema.ts` | All new fields added; array fields use `z.array(z.string())` |
| `VolunteerForm.tsx` | Added `InfoBlock` renderer, `select`, `checkbox-group` support, `hint` display |
| `route.ts` | Added `ARRAY_REQUIRED_KEYS` + `ACCEPTANCE_RADIO_KEYS` sets for correct required-field gating; skips `info` type fields |
| `page.tsx` | Added `** THIS IS A VOLUNTEER APPLICATION ONLY **` amber banner |

### Build verification

`npm run build` passes cleanly — 0 type errors, 0 compile errors, Tailwind output verified.

## Test plan

- [ ] Load `/apply/volunteer` — verify application-only banner visible
- [ ] Submit with all required fields empty — verify error highlights per section
- [ ] Fill all 14 sections and submit — verify success state
- [ ] Confirm info/text blocks (Code of Conduct, Waiver, Agreement) render as styled prose, not inputs
- [ ] Confirm `transport_vehicle_type` checkbox-group (Car / SUV / Other) stores array
- [ ] Confirm `roles` canonical checkboxes still work
- [ ] Confirm `hours_per_week` select dropdown renders correctly
- [ ] Verify `hint` text displays in italic gray below Insurance Company label
- [ ] Confirm Supabase payload includes all new fields in `applicant_profile.payload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)