### PR TITLE
CR-37: Move Good With and Health Info above descriptions

### DIFF
--- a/src/app/(main)/available-danes/[slug]/page.tsx
+++ b/src/app/(main)/available-danes/[slug]/page.tsx
@@ -180,24 +180,6 @@ export default async function DogDetailPage({
           </div>
         </div>
 
-        {/* Short Description */}
-        {dog.shortDescription && (
-          <div className="mb-8 p-6 bg-teal-50 rounded-xl border-l-4 border-teal-500">
-            <p className="text-xl text-gray-800 leading-relaxed italic">
-              {dog.shortDescription}
-            </p>
-          </div>
-        )}
-
-        {/* Full Description */}
-        {dog.description && (
-          <div className="mb-8">
-            <div className="prose prose-lg max-w-none text-gray-700 whitespace-pre-line">
-              {dog.description}
-            </div>
-          </div>
-        )}
-
         {/* Good With */}
         {dog.goodWith && dog.goodWith.length > 0 && (
           <div className="mb-8">
@@ -257,6 +239,24 @@ export default async function DogDetailPage({
             </div>
           )}
         </div>
+
+        {/* Short Description */}
+        {dog.shortDescription && (
+          <div className="mb-8 p-6 bg-teal-50 rounded-xl border-l-4 border-teal-500">
+            <p className="text-xl text-gray-800 leading-relaxed italic">
+              {dog.shortDescription}
+            </p>
+          </div>
+        )}
+
+        {/* Full Description */}
+        {dog.description && (
+          <div className="mb-8">
+            <div className="prose prose-lg max-w-none text-gray-700 whitespace-pre-line">
+              {dog.description}
+            </div>
+          </div>
+        )}
 
         {/* CTA */}
         {(dog.status === "available" || dog.status === "under-evaluation") && (


### PR DESCRIPTION
## Summary
- Moves **Good With** and **Health Information** sections to display directly under the basic info card (Sex, Age, Ears, Color, Weight, Location) on individual dog detail pages
- Short Description and Full Description now appear below these sections
- No content added or removed — sections reordered only

## Section order (before → after)
| Before | After |
|---|---|
| Basic Info | Basic Info |
| Short Description | **Good With** |
| Full Description | **Health Information** |
| Good With | Short Description |
| Health Information | Full Description |
| CTA | CTA |

## Test plan
- [ ] Open any dog detail page (e.g. `/available-danes/saige`)
- [ ] Verify Good With appears directly under the basic info card
- [ ] Verify Health Information appears after Good With
- [ ] Verify Short Description and Full Description appear after Health Info
- [ ] Verify CTA remains at the bottom

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)