### PR TITLE
CR-38: Make Home Phone not required on volunteer form

### DIFF
--- a/src/lib/forms/volunteer/field-map.ts
+++ b/src/lib/forms/volunteer/field-map.ts
@@ -40,7 +40,7 @@ export const VOLUNTEER_FIELD_MAP: FieldDef[] = [
   { key: "address_state",        label: "State",         required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. CO" },
   { key: "address_zip",          label: "Zip Code",      required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. 80202" },
   { key: "email",                label: "Email",         required: true,  type: "email", section: "Applicant Information", placeholder: "you@example.com" },
-  { key: "phone_primary",        label: "Home Phone",    required: true,  type: "tel",   section: "Applicant Information" },
+  { key: "phone_primary",        label: "Home Phone",    required: false, type: "tel",   section: "Applicant Information" },
   { key: "phone_mobile",         label: "Mobile Phone",  required: true,  type: "tel",   section: "Applicant Information" },
   { key: "age",                  label: "Age",           required: true,  type: "text",  section: "Applicant Information", placeholder: "e.g. 28" },
 

--- a/src/lib/forms/volunteer/schema.ts
+++ b/src/lib/forms/volunteer/schema.ts
@@ -21,7 +21,7 @@ export const volunteerSchema = z
     address_state:        s(),
     address_zip:          s(),
     email:                z.string().trim().email("Invalid email address"),
-    phone_primary:        s(),
+    phone_primary:        sOpt(),
     phone_mobile:         s(),
     age:                  s(),
 


### PR DESCRIPTION
## Summary
- Removes the required constraint from the Home Phone field on the volunteer application form
- Updated in both `field-map.ts` (UI asterisk + client validation) and `schema.ts` (server-side Zod validation)

## Files changed
- `src/lib/forms/volunteer/field-map.ts` — `required: true` → `required: false`
- `src/lib/forms/volunteer/schema.ts` — `s()` → `sOpt()`

## Test plan
- [ ] Open `/apply/volunteer`
- [ ] Verify Home Phone field no longer shows asterisk (*)
- [ ] Submit form without Home Phone — should succeed
- [ ] Submit form with Home Phone — should still work

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)