### PR TITLE
fix: CR approval workflow cleans all intermediate labels on closure

### DIFF
--- a/.github/workflows/cr-approval.yml
+++ b/.github/workflows/cr-approval.yml
@@ -37,15 +37,17 @@ jobs:
             const num = context.issue.number;
             const approver = context.payload.comment.user.login;
 
-            // ── Swap labels: cr-review → cr-closed ──
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: num,
-                name: 'cr-review'
-              });
-            } catch (e) {}
+            // ── Clean all intermediate labels, set cr-closed ──
+            for (const label of ['cr-pending', 'cr-queued', 'cr-executing', 'cr-review', 'cr-done']) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: num,
+                  name: label
+                });
+              } catch (e) { /* label may not exist */ }
+            }
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -154,15 +156,17 @@ jobs:
 
               const approver = approvalReaction.user.login;
 
-              // ── Same closure logic as comment-approval ──
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  name: 'cr-review'
-                });
-              } catch (e) {}
+              // ── Clean all intermediate labels, set cr-closed ──
+              for (const label of ['cr-pending', 'cr-queued', 'cr-executing', 'cr-review', 'cr-done']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                } catch (e) { /* label may not exist */ }
+              }
 
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- CR approval workflow now removes ALL intermediate lifecycle labels on closure
- Previously only removed `cr-review`; now removes `cr-pending`, `cr-queued`, `cr-executing`, `cr-review`, `cr-done`
- Prevents label accumulation that caused 10 closed issues to retain stale labels

## Context
Remediation per ATLAS-CR-002 (R2/R3). The CR-MCP-State-Machine-Spec-v1 requires "exactly one state at any time." Leftover intermediate labels violated this rule.

## Test plan
- [x] Label backlog cleared (ATLAS-CR-002)
- [ ] Merge to main
- [ ] Smoke test: create test CR, process through approval, verify only cr-closed label remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)