### PR TITLE
CR stop-gate remediation: push verification, production validation, governance logging

### DIFF
--- a/.github/workflows/cr-completion-notifier.yml
+++ b/.github/workflows/cr-completion-notifier.yml
@@ -34,6 +34,27 @@ jobs:
               'Content-Type': 'application/json'
             };
 
+            // ── Governance incident helper ──
+            async function logGovernanceIncident(crNum, gate, detail) {
+              const incidentBody = [
+                `## 🔒 Governance Incident — CR-${crNum}`,
+                '',
+                `**Gate:** ${gate}`,
+                `**Time:** ${new Date().toISOString()}`,
+                `**Detail:** ${detail}`,
+                `**Disposition:** Escalated. Change NOT confirmed as deployed.`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: crNum,
+                body: incidentBody
+              });
+
+              core.error(`[GOVERNANCE-INCIDENT] CR-${crNum} | ${gate} | ${detail}`);
+            }
+
             // ── Fetch tasks in 'review' status (completed but not yet notified) ──
             const res = await fetch(
               `${sbUrl}/rest/v1/cr_tasks?status=eq.review&tenant=eq.rmgdri&select=*`,
@@ -52,7 +73,123 @@ jobs:
               // ── Build preview link (always production) ──
               const previewBase = 'https://rmgdri-site.vercel.app';
               const previewPath = pageUrl ? `/${pageUrl.replace(/^\//, '')}` : '';
-              const previewLink = `**[Review on live site](${previewBase}${previewPath})**`;
+              const liveUrl = `${previewBase}${previewPath}`;
+              const previewLink = `**[Review on live site](${liveUrl})**`;
+
+              // ── STOP-GATE 2: Validate production page before claiming "deployed and live" ──
+              let validationPassed = false;
+              let validationDetail = '';
+
+              if (pageUrl) {
+                try {
+                  const liveRes = await fetch(liveUrl, {
+                    method: 'GET',
+                    headers: { 'Cache-Control': 'no-cache' },
+                    redirect: 'follow',
+                  });
+
+                  if (liveRes.ok) {
+                    const body = await liveRes.text();
+                    if (body.length > 500) {
+                      validationPassed = true;
+                      validationDetail = `HTTP 200, body ${body.length} chars`;
+                      core.info(`  Production validation passed for CR-${crNum}: ${liveUrl} (${body.length} chars)`);
+                    } else {
+                      validationDetail = `HTTP 200 but suspiciously short body (${body.length} chars)`;
+                      core.warning(`  Production validation inconclusive for CR-${crNum}: ${validationDetail}`);
+                    }
+                  } else {
+                    validationDetail = `HTTP ${liveRes.status}`;
+                    core.warning(`  Production validation failed for CR-${crNum}: ${liveUrl} returned ${liveRes.status}`);
+                  }
+                } catch (fetchErr) {
+                  validationDetail = `Fetch error: ${fetchErr.message}`;
+                  core.warning(`  Production fetch failed for CR-${crNum}: ${fetchErr.message}`);
+                }
+              } else {
+                // No page_url — cannot validate, but this is a known limitation
+                validationDetail = 'No page_url provided — cannot validate production page';
+                core.warning(`  CR-${crNum}: No page_url, skipping production validation`);
+              }
+
+              // ── STOP-GATE 3: Gate notification on validation result ──
+              if (!validationPassed) {
+                // Post escalation instead of false "deployed and live"
+                const escalationBody = [
+                  `## ⚠️ CR-${crNum} — pushed but NOT validated live`,
+                  '',
+                  pageUrl ? `**Page:** ${pageUrl}` : '',
+                  result.commit ? `**Commit:** \`${result.commit}\`` : '',
+                  `**Validation:** ${validationDetail}`,
+                  '',
+                  'Production validation did not confirm this change is live and correct.',
+                  'A team member will verify manually before confirming completion.',
+                  '',
+                  `1. ${previewLink}`,
+                  '2. Check the page manually and reply with status.',
+                ].filter(Boolean).join('\n');
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: crNum,
+                  body: escalationBody
+                });
+
+                // Cross-post to source PR if applicable
+                if (source === 'github-pr-comment' && payload.pr_number) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: payload.pr_number,
+                    body: [
+                      `## ⚠️ CR-${crNum} — pushed but NOT validated live`,
+                      '',
+                      `**Tracking issue:** #${crNum}`,
+                      'Production validation did not pass. A team member will verify.',
+                    ].join('\n')
+                  });
+                }
+
+                // Log governance incident
+                await logGovernanceIncident(crNum, 'production-validation',
+                  `Production validation failed for ${liveUrl}: ${validationDetail}`
+                );
+
+                // Mark as validation-failed — do NOT mark as done
+                await fetch(
+                  `${sbUrl}/rest/v1/cr_tasks?id=eq.${task.id}`,
+                  {
+                    method: 'PATCH',
+                    headers: { ...headers, 'Prefer': 'return=minimal' },
+                    body: JSON.stringify({
+                      status: 'validation-failed',
+                      result: { ...result, validation: validationDetail }
+                    })
+                  }
+                );
+
+                // Update labels
+                for (const label of ['cr-queued', 'cr-executing', 'cr-pending']) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: crNum,
+                      name: label
+                    });
+                  } catch (e) { /* label may not exist */ }
+                }
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: crNum,
+                  labels: ['cr-validation-failed']
+                });
+
+                core.warning(`CR-${crNum}: Production validation failed — NOT notified as deployed`);
+                continue; // Skip the "deployed and live" notification
+              }
 
               // ── Build a short excerpt of the original request ──
               const desc = task.description || '';
@@ -61,9 +198,9 @@ jobs:
                 ? `[original request](${task.source_url})`
                 : 'original request';
 
-              // ── Build completion comment ──
+              // ── Build completion comment (only reached if validation passed) ──
               let comment = [
-                `## ✅ CR-${crNum} deployed and live`,
+                `## ✅ CR-${crNum} deployed and validated live`,
                 '',
               ];
 
@@ -79,6 +216,7 @@ jobs:
               if (result.files_changed?.length) {
                 comment.push(`**Files changed:** ${result.files_changed.join(', ')}`);
               }
+              comment.push(`**Validation:** ${validationDetail}`);
 
               comment.push('');
               comment.push(`### Please validate`);
@@ -104,7 +242,7 @@ jobs:
                   repo: context.repo.repo,
                   issue_number: payload.pr_number,
                   body: [
-                    `## ✅ CR-${crNum} deployed and live`,
+                    `## ✅ CR-${crNum} deployed and validated live`,
                     '',
                     pageUrl ? `**Page:** ${pageUrl}` : '',
                     `**Tracking issue:** #${crNum}`,
@@ -141,17 +279,18 @@ jobs:
                   headers: { ...headers, 'Prefer': 'return=minimal' },
                   body: JSON.stringify({
                     status: 'done',
-                    completed_at: new Date().toISOString()
+                    completed_at: new Date().toISOString(),
+                    result: { ...result, validation: validationDetail }
                   })
                 }
               );
 
-              core.info(`Notified CR-${crNum} completion`);
+              core.info(`Notified CR-${crNum} completion (validated)`);
             }
 
             // ── Handle failed/blocked tasks ──
             const failRes = await fetch(
-              `${sbUrl}/rest/v1/cr_tasks?status=in.(failed,blocked,escalated)&tenant=eq.rmgdri&error=not.is.null&select=*`,
+              `${sbUrl}/rest/v1/cr_tasks?status=in.(failed,blocked,escalated,validation-failed)&tenant=eq.rmgdri&error=not.is.null&select=*`,
               { headers }
             );
             if (!failRes.ok) return;
@@ -175,6 +314,9 @@ jobs:
               } else if (task.status === 'failed') {
                 emoji = '⚠️';
                 statusText = 'encountered a build error — escalated to Ray';
+              } else if (task.status === 'validation-failed') {
+                emoji = '⚠️';
+                statusText = 'was pushed but production validation failed';
               }
 
               const failDesc = task.description || '';

--- a/.github/workflows/cr-executor.yml
+++ b/.github/workflows/cr-executor.yml
@@ -214,6 +214,27 @@ jobs:
               });
             }
 
+            // ── Governance incident helper ──
+            async function logGovernanceIncident(crNumber, gate, detail) {
+              const incidentBody = [
+                `## 🔒 Governance Incident — CR-${crNumber}`,
+                '',
+                `**Gate:** ${gate}`,
+                `**Time:** ${new Date().toISOString()}`,
+                `**Detail:** ${detail}`,
+                `**Disposition:** Escalated. Change NOT marked as deployed.`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: crNumber,
+                body: incidentBody
+              });
+
+              core.error(`[GOVERNANCE-INCIDENT] CR-${crNumber} | ${gate} | ${detail}`);
+            }
+
             // ══════════════════════════════════════════
             // ── MAIN: Fetch and execute pending tasks ──
             // ══════════════════════════════════════════
@@ -373,13 +394,36 @@ jobs:
                 await escalate(crNum,
                   `Git commit/push failed: ${gitErr.message}`
                 );
+                await logGovernanceIncident(crNum, 'commit-push',
+                  `Git commit/push operation failed: ${gitErr.message}`
+                );
                 continue;
               }
 
-              // ── Get commit SHA ──
+              // ── STOP-GATE 1: Verify push landed on remote ──
               const commitSha = execSync('git rev-parse --short HEAD', {
                 encoding: 'utf-8'
               }).trim();
+              const fullSha = execSync('git rev-parse HEAD', {
+                encoding: 'utf-8'
+              }).trim();
+
+              try {
+                execSync('git fetch origin main', { encoding: 'utf-8' });
+                execSync(`git merge-base --is-ancestor ${fullSha} origin/main`, {
+                  encoding: 'utf-8',
+                  stdio: 'pipe'
+                });
+                core.info(`  Push verified: ${commitSha} confirmed on origin/main`);
+              } catch (verifyErr) {
+                // Push did not land — escalate, do NOT mark as review
+                const reason = `Push appeared to succeed but remote verification failed. ` +
+                  `Commit ${commitSha} is NOT confirmed on origin/main. ` +
+                  `Change may NOT be deployed. Escalating for manual review.`;
+                await escalate(crNum, reason);
+                await logGovernanceIncident(crNum, 'push-verification', reason);
+                continue;
+              }
 
               // ── Update Supabase: status → review ──
               await updateTask(crNum, {

--- a/scripts/cr-executor.mjs
+++ b/scripts/cr-executor.mjs
@@ -248,12 +248,38 @@ async function executeTask(task) {
       filesChanged = diffStat.split('\n').filter(Boolean);
     } catch (e) { /* no commit made */ }
 
-    // Push to branch
+    // ── STOP-GATE: Push and verify ──
     if (commit) {
       try {
         execSync(`git push origin ${tenant.branch}`, { cwd: tenant.repo, encoding: 'utf-8' });
-      } catch (e) {
-        console.warn('Push failed:', e.message);
+      } catch (pushErr) {
+        // Push failed — hard stop, escalate immediately
+        await updateTask(task.id, {
+          status: 'escalated',
+          error: `Push to ${tenant.branch} failed: ${pushErr.message?.slice(0, 500)}`,
+        });
+        console.error(`CR-${task.cr_number}: Push FAILED — escalated (not marking as review)`);
+        return;
+      }
+
+      // Verify push landed on remote
+      try {
+        const fullSha = execSync('git rev-parse HEAD', { cwd: tenant.repo, encoding: 'utf-8' }).trim();
+        execSync(`git fetch origin ${tenant.branch}`, { cwd: tenant.repo, encoding: 'utf-8' });
+        execSync(`git merge-base --is-ancestor ${fullSha} origin/${tenant.branch}`, {
+          cwd: tenant.repo,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+        });
+        console.log(`  Push verified: ${commit} confirmed on origin/${tenant.branch}`);
+      } catch (verifyErr) {
+        // Push appeared to succeed but verification failed
+        await updateTask(task.id, {
+          status: 'escalated',
+          error: `Push verification failed: commit ${commit} not confirmed on origin/${tenant.branch}. ${verifyErr.message?.slice(0, 300)}`,
+        });
+        console.error(`CR-${task.cr_number}: Push verification FAILED — escalated`);
+        return;
       }
     }
 

--- a/scripts/validation-descriptor-schema.yaml
+++ b/scripts/validation-descriptor-schema.yaml
@@ -1,0 +1,9 @@
+# Validation Descriptor Schema
+
+validation:
+  type: content_match | selector | token | custom
+  target_url: string
+  expectation:
+    value: string
+    match_type: exact | contains | regex
+  failure_mode: fail_closed

--- a/scripts/validation-engine.sh
+++ b/scripts/validation-engine.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="$1"
+EXPECT="$2"
+
+BODY="$(curl -s "$URL")"
+
+if [[ "$BODY" == *"$EXPECT"* ]]; then
+  echo "VALIDATED_SUCCESS"
+  exit 0
+else
+  echo "VALIDATION_FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Add governance stop-gates to the CR automated execution pipeline, closing the validation gap where changes could be declared "deployed and live" without production verification.

- Add remote push verification after every `git push` in the executor workflow
- Add blocking production page validation before any completion notification
- Convert push failure handling from silent warning to hard stop with escalation
- Add governance incident logging on all control failures
- Introduce `validation-failed` status and `cr-validation-failed` label for the failure path
- Change notification language from "deployed and live" to "deployed and validated live" only when validation succeeds

## Files changed
- `.github/workflows/cr-executor.yml` — push verification gate + incident logging
- `.github/workflows/cr-completion-notifier.yml` — production validation gate + conditional notification
- `scripts/cr-executor.mjs` — blocking push failure + push verification
- `scripts/validation-engine.sh` — semantic validation helper (new)
- `scripts/validation-descriptor-schema.yaml` — validation descriptor model (new)

## Governance trail
- TTP-CR-STOPGATE-001 — assessment (6 findings, 1 critical)
- TTP-CR-STOPGATE-002 — implementation patch preparation
- TTP-CR-STOPGATE-003 — governance review, Honey Badger conditional approval
- TTP-CR-STOPGATE-004 — semantic validation refinement
- TTP-CR-STOPGATE-005 — controlled apply (this PR)

## Test plan
- [ ] Verify `npm run build` passes on branch
- [ ] Trigger `cr-executor.yml` via workflow_dispatch — confirm push verification log output
- [ ] Trigger `cr-completion-notifier.yml` via workflow_dispatch — confirm production validation log output
- [ ] Confirm "deployed and validated live" language appears only on validation pass
- [ ] Confirm "pushed but NOT validated live" language appears on validation failure
- [ ] Confirm governance incident comments are posted on gate failures
- [ ] Post-merge: fetch live production pages to validate deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)