### PR TITLE
CR-47: Add gallery photos to dog detail page

### DIFF
--- a/src/app/(main)/available-danes/[slug]/page.tsx
+++ b/src/app/(main)/available-danes/[slug]/page.tsx
@@ -29,6 +29,12 @@ type Dog = {
       url?: string;
     };
   };
+  gallery?: {
+    asset?: {
+      url?: string;
+    };
+    caption?: string;
+  }[];
 };
 
 const DOG_QUERY = /* groq */ `*[_type == "dog" && slug.current == $slug && hideFromWebsite != true][0]{
@@ -56,6 +62,12 @@ const DOG_QUERY = /* groq */ `*[_type == "dog" && slug.current == $slug && hideF
     asset-> {
       url
     }
+  },
+  gallery[] {
+    asset-> {
+      url
+    },
+    caption
   }
 }`;
 
@@ -179,6 +191,32 @@ export default async function DogDetailPage({
             </div>
           </div>
         </div>
+
+        {/* Additional Photos */}
+        {dog.gallery && dog.gallery.length > 0 && (
+          <div className="mb-8">
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">More Photos</h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {dog.gallery.map((photo, index) => (
+                <div key={index} className="relative aspect-square rounded-xl overflow-hidden bg-gray-100">
+                  {photo.asset?.url ? (
+                    <Image
+                      src={photo.asset.url}
+                      alt={photo.caption || `${dog.name || "Dog"} photo ${index + 1}`}
+                      fill
+                      className="object-cover"
+                    />
+                  ) : null}
+                  {photo.caption && (
+                    <p className="absolute bottom-0 left-0 right-0 bg-black/50 text-white text-sm px-3 py-1.5">
+                      {photo.caption}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Good With */}
         {dog.goodWith && dog.goodWith.length > 0 && (


### PR DESCRIPTION
## Summary
Add additional photo gallery query and rendering to the dog detail page, recovering CR-47 (Saige) after a false completion notification from the automated pipeline.

## Root cause
The GROQ query in `[slug]/page.tsx` fetched `mainImage` but **not** the `gallery` field. The gallery (Additional Photos) existed in the Sanity schema but was neither queried nor rendered. Lori added 3 photos to Saige in Sanity Studio, but no code path existed to display them.

## Changes (1 file, 38 insertions)
- **Type definition**: Added `gallery` array type with `asset.url` and `caption`
- **GROQ query**: Added `gallery[]{ asset->{ url }, caption }` field
- **Rendering**: Added photo grid section below the hero image with captions

## Description field
The `description` (Full Description) code path is already correct — query fetches it, template renders it. If Lori's updated description still doesn't show after this deploy, it's a CMS publish state or cache issue, not a code issue.

## Governance note
- CR-47 was previously reported as "deployed and live" by the automated pipeline with no corresponding commit — that was a false positive
- This recovery was performed through manual governed review (TTP-CR-47-SAIGE-RECOVERY-001)
- **Do not claim resolved until the live Saige page shows the additional photos**

## Test plan
- [ ] `npm run build` passes
- [ ] After merge, verify https://rmgdri-site.vercel.app/available-danes/saige shows additional photos
- [ ] Verify updated description appears on the live page
- [ ] Compare live page against Sanity Studio canonical content for Saige

🤖 Generated with [Claude Code](https://claude.com/claude-code)