### PR TITLE
CR-55: Switch event dates to native datetime picker

### DIFF
--- a/sanity/schemaTypes/event.ts
+++ b/sanity/schemaTypes/event.ts
@@ -55,26 +55,15 @@ export default defineType({
     defineField({
       name: 'startDate',
       title: 'Start Date & Time',
-      type: 'string',
-      description: 'Format: Month DD, YYYY HH:MM AM/PM (e.g., February 15, 2025 2:30 PM)',
-      placeholder: 'February 15, 2025 2:30 PM',
-      validation: (Rule) =>
-        Rule.required().regex(
-          /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}\s+\d{1,2}:\d{2}\s+(AM|PM)$/,
-          'Must be "Month DD, YYYY HH:MM AM/PM" format (e.g., February 15, 2025 2:30 PM)'
-        ),
+      type: 'datetime',
+      description: 'Format: YYYY-MM-DD (e.g., 2026-04-11). Time not needed for events.',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: 'endDate',
       title: 'End Date & Time',
-      type: 'string',
-      description: 'Format: Month DD, YYYY HH:MM AM/PM (e.g., February 15, 2025 5:00 PM). Leave blank for single-day events',
-      placeholder: 'February 15, 2025 5:00 PM',
-      validation: (Rule) =>
-        Rule.regex(
-          /^(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}\s+\d{1,2}:\d{2}\s+(AM|PM)$/,
-          'Must be "Month DD, YYYY HH:MM AM/PM" format (e.g., February 15, 2025 5:00 PM)'
-        ),
+      type: 'datetime',
+      description: 'Format: YYYY-MM-DD (e.g., 2026-04-11). Leave blank for single-day events',
     }),
     defineField({
       name: 'location',


### PR DESCRIPTION
## Summary
Replace the fragile string+regex date fields on events with Sanity's native `datetime` type and built-in date/time picker.

## Root cause
The event schema used `type: 'string'` with a regex validator requiring exact format: `"February 15, 2025 2:30 PM"`. Users typing dates with slightly different spacing (e.g., double space before the time) triggered validation errors even though the date was correct.

## Fix
Switch `startDate` and `endDate` from `type: 'string'` to `type: 'datetime'`. This gives editors a calendar/time picker widget instead of a freeform text field — no more format-dependent errors.

## Why this is the right fix
- A regex on a text field is the wrong UX for date entry
- Sanity's `datetime` type exists for exactly this purpose
- The frontend already uses `new Date()` to parse these fields — ISO 8601 strings from the native type parse more reliably than the human-readable format
- Eliminates the entire class of "format is correct but rejected" bugs

## Impact
- **Schema change:** `startDate` and `endDate` field types change from `string` to `datetime`
- **Existing data:** Any existing events stored as human-readable strings will need to be re-entered using the new picker. There are currently very few events in the system.
- **Frontend:** No changes needed — `new Date()` handles ISO 8601 natively

## Test plan
- [ ] Build passes
- [ ] Open Sanity Studio → Events → create new event
- [ ] Confirm date/time picker appears (not a text field)
- [ ] Enter: April 11, 2026 9:00 AM start, April 11, 2026 12:00 PM end
- [ ] Publish successfully
- [ ] Verify the event renders correctly on /utah-events

🤖 Generated with [Claude Code](https://claude.com/claude-code)