### PR TITLE
CR service: trigger executor from intake for auto-execute CRs

### DIFF
--- a/.github/workflows/cr-intake.yml
+++ b/.github/workflows/cr-intake.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      actions: write
     steps:
       - name: Parse, label, acknowledge, and queue to Supabase
         uses: actions/github-script@v7
@@ -198,6 +199,26 @@ jobs:
                   issue_number: num,
                   labels: ['cr-queued']
                 });
+
+                // ── Trigger executor promptly for auto-execute CRs ──
+                // This eliminates the 30-90 minute cron wait.
+                // Manual-path CRs do NOT trigger the executor.
+                // Cron remains as fallback if this dispatch fails.
+                if (autoExecute) {
+                  try {
+                    await github.rest.actions.createWorkflowDispatch({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      workflow_id: 'cr-executor.yml',
+                      ref: 'main'
+                    });
+                    core.info(`CR-${num}: Triggered executor via workflow_dispatch (auto-execute eligible)`);
+                  } catch (dispatchErr) {
+                    core.warning(`CR-${num}: Failed to trigger executor dispatch: ${dispatchErr.message}. Cron fallback will handle.`);
+                  }
+                } else {
+                  core.info(`CR-${num}: Not auto-execute eligible (${routeLabel}) — executor NOT triggered`);
+                }
               } else {
                 const err = await res.text();
                 core.warning(`Failed to queue CR-${num} to Supabase: ${err}`);


### PR DESCRIPTION
## Summary
- Trigger executor workflow directly from intake when a new auto-execute eligible CR is queued
- Eliminates 30–90 minute cron wait for fresh CRs
- Manual-path CRs do NOT trigger executor
- Cron remains as fallback

## Why
Service diagnostic (TTP-CR-WORKFLOW-E2E-SERVICE-DIAGNOSTIC-001) found that GitHub cron throttle causes 30–90 minute ambiguous pending windows (IMP-001). Target SLA is 5–15 minutes.

## What changed
- `.github/workflows/cr-intake.yml`: Added `actions: write` permission + `workflow_dispatch` call after Supabase queue, guarded by `if (autoExecute)`

## Safety
- Only `autoExecute === true` CRs trigger dispatch
- Manual-path classes (`cr-developer-required`, `cr-cms-manual`, `cr-studio-bug`, `cr-manual-review`) do NOT trigger
- Dispatch failure is non-fatal (warning logged, cron handles)
- Executor still validates `auto_execute=true & category=content-update` from Supabase

## Test plan
1. Submit content-update CR → executor should start within minutes (not 30-90 min)
2. Submit bug CR → executor should NOT be triggered
3. If dispatch fails → cron fallback picks up within normal window

## Governance
TTP-CR-SERVICE-STABILIZATION-017-INTAKE-TO-EXECUTOR-TRIGGER