### PR TITLE
CR service: derive validation hints from git diff instead of title regex

### DIFF
--- a/.github/workflows/cr-executor.yml
+++ b/.github/workflows/cr-executor.yml
@@ -428,11 +428,40 @@ jobs:
               // ── Build semantic validation hint for the notifier ──
               // The notifier will search the live page for this text.
               // If not found, the notifier fails closed instead of claiming success.
-              // Extract quoted text from title if present, otherwise use the full title.
-              const quotedMatch = title.match(/['"]([^'"]{3,})['"]/);
-              const validationHint = quotedMatch
-                ? quotedMatch[1]
-                : (description.match(/['"]([^'"]{3,})['"]/)?.[1] || '');
+              //
+              // Priority: diff-derived text > quoted text in title/description > empty (fail closed)
+              let validationHint = '';
+
+              // Strategy 1: Extract from actual git diff (most reliable)
+              try {
+                const diffText = execSync(
+                  `git diff HEAD~1 HEAD -- ${changedFiles.map(f => `"${f}"`).join(' ')}`,
+                  { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+                );
+                const addedLines = diffText.split('\n')
+                  .filter(l => l.startsWith('+') && !l.startsWith('+++'))
+                  .map(l => l.slice(1).trim())
+                  .filter(l => {
+                    if (l.length < 10) return false;
+                    if (/^[<{}\[\]\/\*]|^import |^export |^const |^let |^var |^function |^return |^if |^else /.test(l)) return false;
+                    if (/^className=|^style=/.test(l)) return false;
+                    return /[a-zA-Z]{3,}/.test(l);
+                  });
+                if (addedLines.length > 0) {
+                  const plain = addedLines[0].replace(/<[^>]+>/g, '').replace(/[{}]/g, '').replace(/&[a-z]+;/g, ' ').replace(/\s+/g, ' ').trim();
+                  if (plain.length >= 8) validationHint = plain.slice(0, 80);
+                }
+              } catch (e) {
+                core.warning(`  Diff hint extraction failed: ${e.message}`);
+              }
+
+              // Strategy 2: Fallback to quoted text in title/description
+              if (!validationHint) {
+                const quotedMatch = title.match(/['"]([^'"]{3,})['"]/);
+                validationHint = quotedMatch
+                  ? quotedMatch[1]
+                  : (description.match(/['"]([^'"]{3,})['"]/)?.[1] || '');
+              }
 
               // ── Update Supabase: status → review ──
               await updateTask(crNum, {

--- a/scripts/cr-executor.mjs
+++ b/scripts/cr-executor.mjs
@@ -331,12 +331,43 @@ async function executeTask(task) {
       : tenant.previewBase;
 
     // Build semantic validation hint for the notifier
+    // Priority: diff-derived text > quoted text in title/description > empty (fail closed)
     const title = task.title || '';
     const desc = task.description || '';
-    const quotedMatch = title.match(/['"]([^'"]{3,})['"]/);
-    const validationHint = quotedMatch
-      ? quotedMatch[1]
-      : (desc.match(/['"]([^'"]{3,})['"]/)?.[1] || '');
+    let validationHint = '';
+
+    // Strategy 1: Extract from actual git diff (most reliable)
+    if (commit && filesChanged.length > 0) {
+      try {
+        const diffText = execSync(
+          `git diff HEAD~1 HEAD -- ${filesChanged.map(f => `"${f}"`).join(' ')}`,
+          { cwd: tenant.repo, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+        );
+        const addedLines = diffText.split('\n')
+          .filter(l => l.startsWith('+') && !l.startsWith('+++'))
+          .map(l => l.slice(1).trim())
+          .filter(l => {
+            if (l.length < 10) return false;
+            if (/^[<{}\[\]\/\*]|^import |^export |^const |^let |^var |^function |^return |^if |^else /.test(l)) return false;
+            if (/^className=|^style=/.test(l)) return false;
+            return /[a-zA-Z]{3,}/.test(l);
+          });
+        if (addedLines.length > 0) {
+          const plain = addedLines[0].replace(/<[^>]+>/g, '').replace(/[{}]/g, '').replace(/&[a-z]+;/g, ' ').replace(/\s+/g, ' ').trim();
+          if (plain.length >= 8) validationHint = plain.slice(0, 80);
+        }
+      } catch (e) {
+        console.warn(`  Diff hint extraction failed: ${e.message}`);
+      }
+    }
+
+    // Strategy 2: Fallback to quoted text in title/description
+    if (!validationHint) {
+      const quotedMatch = title.match(/['"]([^'"]{3,})['"]/);
+      validationHint = quotedMatch
+        ? quotedMatch[1]
+        : (desc.match(/['"]([^'"]{3,})['"]/)?.[1] || '');
+    }
 
     if (validationHint) {
       console.log(`  Validation hint: "${validationHint}"`);


### PR DESCRIPTION
## Summary
- Generate validation hints from actual git diff output instead of regex-matching quoted text in CR title
- Fixes the #1 cause of false validation failure (60% of recent auto-execute CRs)

## Why
Service diagnostic (TTP-CR-WORKFLOW-E2E-SERVICE-DIAGNOSTIC-001) found that validation hint extraction fails on most CRs because titles rarely contain quoted text. CRs like "Text Change to test CR Workflow" (CR-52) and "Add a new badge to dog detail page" (CR-54) both failed with VALIDATION_DESCRIPTOR_MISSING.

## What changed
Both `.github/workflows/cr-executor.yml` and `scripts/cr-executor.mjs`:
- **New Strategy 1:** Extract first substantive text addition from `git diff HEAD~1 HEAD`
  - Filters out code syntax, JSX tags, imports, className attributes
  - Strips HTML to get plain text
  - Truncates to 80 chars
- **Existing Strategy 2:** Fallback to quoted text in title/description
- **Fail-closed preserved:** If no hint can be derived, `validation_hint` remains empty → notifier fails closed (DESCRIPTOR_MISSING)

## Safety
- No fabricated hints — only actual diff-derived text
- Fail-closed behavior preserved for ambiguous changes
- Title regex fallback retained
- No changes to notifier validation logic

## Test plan
1. Content-update with descriptive text change → diff-derived hint produced
2. Code-only change with no readable text → fallback to title or fail closed
3. CR with quoted title → title regex still works as fallback
4. Ambiguous change → fail closed (no false success claim)

## Governance
TTP-CR-SERVICE-STABILIZATION-016-VALIDATION-HINT-GENERATION