### PR TITLE
fix: remove duplicate governance incident call (cert-001 repair)

### DIFF
--- a/.github/workflows/cr-completion-notifier.yml
+++ b/.github/workflows/cr-completion-notifier.yml
@@ -307,12 +307,8 @@ jobs:
 
                 // Log governance incident
                 await logGovernanceIncident(crNum, 'production-validation',
-                
-await logGovernanceIncident(
-  crNum,
-  'production-validation',
-  `${validationOutcome} for ${liveUrl || '(no valid review URL)'}: ${validationDetail}`
-);
+                  `${validationOutcome} for ${liveUrl || '(no valid review URL)'}: ${validationDetail}`
+                );
 
                 // Mark as validation-failed with subclass detail
                 await fetch(


### PR DESCRIPTION
## Summary

Removes a duplicate `logGovernanceIncident` call introduced by a merge conflict resolution in commit `fa03c13` (when PR #69 was rebased onto #68 before merging).

## The defect

The governance incident block in `cr-completion-notifier.yml` was left in this state after the conflict resolution:

```javascript
await logGovernanceIncident(crNum, 'production-validation',

await logGovernanceIncident(
  crNum,
  'production-validation',
  `${validationOutcome} for ${liveUrl || '(no valid review URL)'}: ${validationDetail}`
);
```

JavaScript parsed the second `await logGovernanceIncident(...)` as the **third argument** of the first call. This caused two sequential incident comment posts per validation failure:
1. Inner call (first to execute): correct incident with proper detail string
2. Outer call (second to execute): second incident comment where `detail = undefined`

Every validation failure posted `**Detail:** undefined` as a second governance incident comment.

## The fix

Remove the outer partial call. Single call retained with the correct merged detail string:

```javascript
await logGovernanceIncident(crNum, 'production-validation',
  `${validationOutcome} for ${liveUrl || '(no valid review URL)'}: ${validationDetail}`
);
```

## Identified by

TTP-CR-SERVICE-CERTIFICATION-001-CAMPAIGN-MERGE-AND-LIVE-FIRE-VALIDATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)