### PR TITLE
CR-021: manual-route handoff bridge

### DIFF
--- a/.github/workflows/cr-intake.yml
+++ b/.github/workflows/cr-intake.yml
@@ -138,14 +138,14 @@ jobs:
               ackLines.push('');
               ackLines.push("You'll receive a notification here when work begins and when it's ready for you to review.");
             } else {
-              ackLines.push(`**Status:** Queued for manual handling (${routeLabel})`);
+              ackLines.push(`**Status:** Assigned for manual handling — @${context.repo.owner}`);
               ackLines.push('');
-              ackLines.push('This type of change requires manual review and cannot be processed automatically.');
+              ackLines.push(`This change requires developer action and has been assigned to **@${context.repo.owner}** for triage.`);
               ackLines.push('');
-              ackLines.push('**Service expectation:**');
+              ackLines.push('**What happens next:**');
+              ackLines.push('- The assigned developer will review and action this change directly');
               ackLines.push('- A status update will be posted within **24 hours**');
-              ackLines.push('- If no update appears, an automated reminder will be sent');
-              ackLines.push('- You will be notified when work begins and when it is ready for review');
+              ackLines.push('- You will be notified here when work begins and when it is complete');
             }
 
             await github.rest.issues.createComment({
@@ -195,9 +195,9 @@ jobs:
 
               if (res.ok) {
                 const [row] = await res.json();
-                core.info(`CR-${num} queued to Supabase: ${row.id}`);
+                core.info(`CR-${num} written to Supabase: ${row.id}`);
 
-                // Update label to cr-queued
+                // Remove cr-pending label
                 try {
                   await github.rest.issues.removeLabel({
                     owner: context.repo.owner,
@@ -207,18 +207,17 @@ jobs:
                   });
                 } catch (e) { /* label may not exist yet */ }
 
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: num,
-                  labels: ['cr-queued']
-                });
-
-                // ── Trigger executor promptly for auto-execute CRs ──
-                // This eliminates the 30-90 minute cron wait.
-                // Manual-path CRs do NOT trigger the executor.
-                // Cron remains as fallback if this dispatch fails.
                 if (autoExecute) {
+                  // ── Auto-execute path ──
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    labels: ['cr-queued']
+                  });
+
+                  // Trigger executor promptly — eliminates 30-90 minute cron wait.
+                  // Cron remains as fallback if dispatch fails.
                   try {
                     await github.rest.actions.createWorkflowDispatch({
                       owner: context.repo.owner,
@@ -231,7 +230,35 @@ jobs:
                     core.warning(`CR-${num}: Failed to trigger executor dispatch: ${dispatchErr.message}. Cron fallback will handle.`);
                   }
                 } else {
-                  core.info(`CR-${num}: Not auto-execute eligible (${routeLabel}) — executor NOT triggered`);
+                  // ── Manual-handoff path ──
+                  // Apply honest label: not in executor queue, waiting on a human.
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    labels: ['cr-manual-handoff']
+                  });
+
+                  // PATCH Supabase task to explicit manual-handoff state (queryable).
+                  await fetch(`${sbUrl}/rest/v1/cr_tasks?id=eq.${row.id}`, {
+                    method: 'PATCH',
+                    headers: {
+                      'apikey': sbKey,
+                      'Authorization': `Bearer ${sbKey}`,
+                      'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ status: 'manual-handoff' })
+                  });
+
+                  // Assign issue to repo owner — creates a real GitHub work assignment.
+                  await github.rest.issues.addAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: num,
+                    assignees: [context.repo.owner]
+                  });
+
+                  core.info(`CR-${num}: Manual-handoff — assigned to ${context.repo.owner}, label cr-manual-handoff applied`);
                 }
               } else {
                 const err = await res.text();

--- a/.github/workflows/cr-watchdog.yml
+++ b/.github/workflows/cr-watchdog.yml
@@ -54,7 +54,7 @@ jobs:
             // CHECK 1: Manual-path CRs stale > 24 hours
             // ══════════════════════════════════════════
 
-            const manualLabels = ['cr-developer-required', 'cr-cms-manual', 'cr-studio-bug', 'cr-manual-review'];
+            const manualLabels = ['cr-developer-required', 'cr-cms-manual', 'cr-studio-bug', 'cr-manual-review', 'cr-manual-handoff'];
 
             for (const label of manualLabels) {
               const issues = await github.rest.issues.listForRepo({


### PR DESCRIPTION
## Summary

- Manual-route CRs (auto_execute=false) were stalling: `cr-queued` label + `status=pending` indefinitely, with no executor ever picking them up
- Replaces the dishonest `cr-queued` label with `cr-manual-handoff` — honest signal that this is not in the executor queue
- PATCHes Supabase `status` to `manual-handoff` — distinct, queryable state
- Assigns the GitHub issue to `context.repo.owner` — real work assignment, not just a watchdog reminder
- Updates ack comment to name the assignee and describe what actually happens next
- Adds `cr-manual-handoff` to watchdog monitored labels so SLA monitoring kicks in immediately

Auto-execute path (cr-queued + workflow_dispatch trigger) is unchanged.

## Files changed

- `.github/workflows/cr-intake.yml` — split post-Supabase block into auto/manual paths; updated ack comment
- `.github/workflows/cr-watchdog.yml` — added `cr-manual-handoff` to `manualLabels`

## Test plan

- [ ] Submit a `cr-developer-required` CR — confirm `cr-manual-handoff` label applied, issue assigned to owner, Supabase `status=manual-handoff`, ack comment names assignee
- [ ] Submit a `content-update` CR — confirm auto-execute path unchanged: `cr-queued`, executor triggered, no assignment
- [ ] Confirm watchdog SLA check covers `cr-manual-handoff` labeled issues at next 6h window

## TTP

TTP-CR-SERVICE-STABILIZATION-021-MANUAL-ROUTE-HANDOFF-BRIDGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)