### PR TITLE
fix(cr-70): add ISR revalidation to adoption-successes pages

### DIFF
--- a/src/app/(main)/adoption-successes/[year]/[slug]/page.tsx
+++ b/src/app/(main)/adoption-successes/[year]/[slug]/page.tsx
@@ -41,6 +41,7 @@ export async function generateStaticParams() {
   return params
 }
 
+export const revalidate = 60
 export const dynamicParams = true
 
 export default async function SuccessDetailPage({ params }: Props) {

--- a/src/app/(main)/adoption-successes/[year]/page.tsx
+++ b/src/app/(main)/adoption-successes/[year]/page.tsx
@@ -20,6 +20,7 @@ export async function generateStaticParams() {
   return years.map(({ year }) => ({ year: String(year) }))
 }
 
+export const revalidate = 60
 export const dynamicParams = true
 
 export default async function YearPage({ params }: Props) {

--- a/src/app/(main)/adoption-successes/page.tsx
+++ b/src/app/(main)/adoption-successes/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { getYears } from '@/lib/adoption-successes'
 
+export const revalidate = 60
+
 export const metadata = {
   title: 'Adoption Successes | RMGDRI',
   description:

--- a/src/lib/adoption-successes.ts
+++ b/src/lib/adoption-successes.ts
@@ -39,7 +39,7 @@ async function getSanityAdopted(): Promise<AdoptionSuccessRecord[]> {
         "mainImageUrl": mainImage.asset->url,
         "adoptionHeroUrl": adoptionHeroImage.asset->url
       }
-    `)
+    `, {}, { next: { revalidate: 60 } })
 
     return dogs.map((dog: any) => {
       const year = parseInt(dog.adoptionYear, 10)


### PR DESCRIPTION
## CR #70 — Revalidation Gap Fix

### What was wrong
All three adoption-successes pages (`/adoption-successes`, `/adoption-successes/[year]`, `/adoption-successes/[year]/[slug]`) had no `revalidate` export. Once statically generated at build time, they cached indefinitely. The Sanity fetch in `lib/adoption-successes.ts` also called `sanityClient.fetch()` without `next: { revalidate }`, bypassing Next.js cache controls.

This is a **rendering/caching issue** — not a data or query issue. Sanity data was correct. The page simply never re-fetched it.

### What was changed
- `adoption-successes/page.tsx`: added `export const revalidate = 60`
- `adoption-successes/[year]/page.tsx`: added `export const revalidate = 60`
- `adoption-successes/[year]/[slug]/page.tsx`: added `export const revalidate = 60`
- `lib/adoption-successes.ts`: added `{ next: { revalidate: 60 } }` to `sanityClient.fetch()` call

Matches the exact pattern already in use on home (`/`) and available-danes pages.

### Recurrence prevention
A dog marked "adopted" in Sanity will now appear on adoption-successes pages within 60 seconds without requiring a redeploy.

Closes #70