### PR TITLE
fix(cr-64): remove dead passphrase gate from intent page

### DIFF
--- a/src/app/admin/intent/page.tsx
+++ b/src/app/admin/intent/page.tsx
@@ -1,58 +1,8 @@
-"use client";
-
-import { useState } from "react";
+import { cookies } from "next/headers";
 import IntentForm from "@/components/admin/IntentForm";
 
-export default function IntentPage() {
-  const [passphrase, setPassphrase] = useState("");
-  const [authed, setAuthed] = useState(false);
-  const [error, setError] = useState("");
-
-  function handleUnlock(e: React.FormEvent) {
-    e.preventDefault();
-    setError("");
-    // We don't call the auth API here — the passphrase is sent as a header
-    // on every /api/intent call. If the first load succeeds, we're good.
-    if (!passphrase.trim()) {
-      setError("Please enter the passphrase.");
-      return;
-    }
-    setAuthed(true);
-  }
-
-  if (!authed) {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="w-full max-w-sm bg-white rounded-lg shadow-md p-8">
-          <h1 className="text-xl font-bold text-gray-900 mb-1 text-center">
-            Intent Engineering Workbook
-          </h1>
-          <p className="text-sm text-gray-500 mb-6 text-center">
-            Enter the admin passphrase to continue.
-          </p>
-          <form onSubmit={handleUnlock} className="space-y-4">
-            <input
-              type="password"
-              value={passphrase}
-              onChange={(e) => setPassphrase(e.target.value)}
-              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="Enter passphrase"
-              autoFocus
-              required
-            />
-            {error && <p className="text-sm text-red-600">{error}</p>}
-            <button
-              type="submit"
-              disabled={!passphrase.trim()}
-              className="w-full bg-gray-900 text-white rounded-md px-4 py-2 text-sm font-medium hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              Open Workbook
-            </button>
-          </form>
-        </div>
-      </div>
-    );
-  }
-
+export default async function IntentPage() {
+  const cookieStore = await cookies();
+  const passphrase = cookieStore.get("admin_session")?.value ?? "";
   return <IntentForm passphrase={passphrase} />;
 }


### PR DESCRIPTION
## CR #64 — Admin Intent Form Fix

### What was wrong
`/admin/intent/page.tsx` was a client component with its own passphrase gate that set React state only — it never set the `admin_session` cookie. The middleware guards all `/admin/*` routes by checking that cookie. So visiting `/admin/intent` triggered a middleware redirect to `/admin/login` before the page's own passphrase form ever rendered. The form was unreachable.

This is a **rendering/auth flow issue** — not a missing route. The route existed. The gate was dead code added before the middleware was built.

### What was changed
`src/app/admin/intent/page.tsx`: converted from 58-line client component with passphrase gate to 8-line server component that reads the already-validated `admin_session` cookie and passes the value to `IntentForm`.

Auth is now handled entirely by the middleware — consistent with every other `/admin/*` route. Users authenticate at `/admin/login`, then navigate to `/admin/intent` directly.

### Verification
TypeScript: clean
Flow: login at `/admin/login` → cookie set → middleware passes `/admin/intent` → server component reads cookie → `IntentForm` renders with passphrase prop

Closes #64