### PR TITLE
CR-025: investigation lane hardening + watchdog coverage

### DIFF
--- a/.github/workflows/cr-intake.yml
+++ b/.github/workflows/cr-intake.yml
@@ -259,6 +259,7 @@ jobs:
                     };
 
                     if (!pUrl) {
+                      result.outcome = 'invalid_url';
                       result.evidence.push('No page URL provided — cannot inspect live page');
                       return result;
                     }
@@ -470,16 +471,13 @@ jobs:
                     if (sanityInv) {
                       inv.sanity = sanityInv;
 
-                      // Sanity signals can override page-based outcome
-                      // If page looks fine but CMS state explains the issue → content_issue_detected
-                      if (sanityInv.signal && inv.outcome === 'no_issue_reproduced') {
+                      // Sanity signals can override non-definitive page outcomes.
+                      // If page says "fine" or "can't tell" but CMS state reveals the issue → content_issue_detected.
+                      const overridable = ['no_issue_reproduced', 'insufficient_data', 'invalid_url'];
+                      if (sanityInv.signal && overridable.includes(inv.outcome)) {
+                        const priorOutcome = inv.outcome;
                         inv.outcome = 'content_issue_detected';
-                        inv.evidence.push(`Sanity CMS signal: ${sanityInv.signal} — overrides no_issue_reproduced`);
-                      }
-                      // If insufficient_data from page but Sanity found something → enrich
-                      if (sanityInv.signal && inv.outcome === 'insufficient_data') {
-                        inv.outcome = 'content_issue_detected';
-                        inv.evidence.push(`Sanity CMS signal: ${sanityInv.signal} — upgraded from insufficient_data`);
+                        inv.evidence.push(`Sanity CMS signal: ${sanityInv.signal} — overrides ${priorOutcome}`);
                       }
                     }
                   } catch (sanityErr) {

--- a/.github/workflows/cr-watchdog.yml
+++ b/.github/workflows/cr-watchdog.yml
@@ -117,6 +117,52 @@ jobs:
               }
             }
 
+            // ══════════════════════════════════════════════════════════════
+            // CHECK 1c: Investigation holding states stale > 72 hours
+            // CRs in cr-hold or cr-needs-clarification awaiting requester action.
+            // ══════════════════════════════════════════════════════════════
+
+            const holdingLabels = ['cr-hold', 'cr-needs-clarification'];
+
+            for (const label of holdingLabels) {
+              const holdIssues = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: label,
+                state: 'open',
+                per_page: 20
+              });
+
+              for (const issue of holdIssues.data) {
+                const ageHours = hoursSince(issue.created_at);
+                const hasRecent = await hasRecentWatchdogComment(issue.number);
+                if (hasRecent) continue;
+
+                if (ageHours > 72) {
+                  const isHold = label === 'cr-hold';
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: [
+                      `## ⏰ Service Watchdog — CR-${issue.number} ${isHold ? 'held without response' : 'awaiting clarification'} for ${Math.round(ageHours)} hours`,
+                      '',
+                      isHold
+                        ? 'This CR was investigated and held because the reported issue could not be reproduced. No follow-up has been received from the requester.'
+                        : 'This CR is awaiting clarification from the requester. No response has been received.',
+                      '',
+                      '**Requester:** please reply with additional detail so this request can be routed correctly.',
+                      '',
+                      '**If no response is received within 7 days**, this issue may be closed as stale.',
+                      '',
+                      '_Automated investigation-hold SLA reminder._'
+                    ].join('\n')
+                  });
+                  core.info(`CR-${issue.number}: Investigation-hold (${label}) stale for ${Math.round(ageHours)}h — watchdog posted`);
+                }
+              }
+            }
+
             // ══════════════════════════════════════════════════════════
             // CHECK 1b: In-progress manual CRs stale > 48 hours
             // Developer marked work started but has not resolved.


### PR DESCRIPTION
## Summary

Closes FINDING-001 and FINDING-002 from TTP-CR-SERVICE-CERTIFICATION-004.

## FINDING-001: invalid_url now reachable

- `investigateCR()` returns `invalid_url` (not `insufficient_data`) when no page URL
- CRs with no URL → `cr-needs-clarification` label, no developer assignment
- Sanity override extended to cover `invalid_url` — if Sanity finds a signal, outcome upgrades to `content_issue_detected`

## FINDING-002: investigation holding states now watchdog-monitored

- New CHECK 1c in `cr-watchdog.yml` for `cr-hold` and `cr-needs-clarification`
- 72h threshold with requester-directed language
- 7-day stale close warning
- Deduped by existing `hasRecentWatchdogComment` guard

## Test plan

- [ ] Bug CR with no URL → `invalid_url` outcome, `cr-needs-clarification`, no assignment
- [ ] Bug CR with no URL + Sanity signal → overrides to `content_issue_detected`, `cr-manual-handoff`
- [ ] `cr-hold` issue open > 72h → watchdog posts reminder
- [ ] `cr-needs-clarification` issue open > 72h → watchdog posts reminder
- [ ] Auto-execute CR unchanged
- [ ] Investigation-first routing for CRs WITH URL unchanged

## TTP

TTP-CR-SERVICE-STABILIZATION-025-INVESTIGATION-LANE-HARDENING-AND-WATCHDOG-COVERAGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)