### PR TITLE
feat(CR-79): add Hidden Dogs list to Studio content menu

### DIFF
--- a/sanity/studioStructure.ts
+++ b/sanity/studioStructure.ts
@@ -68,6 +68,16 @@ export const structure = (S: StructureBuilder) =>
             .defaultOrdering([{ field: 'adoptionDate', direction: 'desc' }])
         ),
 
+      // Hidden from Website (CR-79)
+      S.listItem()
+        .title('🚫 Hidden from Website')
+        .child(
+          S.documentList()
+            .title('Hidden Dogs')
+            .filter('_type == "dog" && hideFromWebsite == true')
+            .defaultOrdering([{ field: 'name', direction: 'asc' }])
+        ),
+
       S.divider(),
 
       // EVENTS SECTION


### PR DESCRIPTION
## Summary

Fixes CR-79: Add a "Hidden from Website" item to the Sanity Studio content menu showing all dogs with `hideFromWebsite=true`.

## Behavior

- New menu item: 🚫 Hidden from Website
- Shows all dogs where `hideFromWebsite == true`, sorted by name
- Dogs still appear under their normal status group (Foster Needed, Available, etc.) — this is an additional view, not a replacement
- Staff can quickly see which dogs are hidden without checking each one individually

## Files

- `sanity/studioStructure.ts` — 10 lines added

🤖 Generated with [Claude Code](https://claude.com/claude-code)