### PR TITLE
feat(studio): hidden dog visibility in all list views (CR-79)

### DIFF
--- a/_ttp/CR-79/CR-79-001-CURRENT-STUDIO-LANDSCAPE.md
+++ b/_ttp/CR-79/CR-79-001-CURRENT-STUDIO-LANDSCAPE.md
@@ -1,0 +1,36 @@
+# CR-79-001: Current Studio Landscape
+
+## Existing Field
+
+- **Field name:** `hideFromWebsite`
+- **Type:** `boolean`
+- **Default:** `false`
+- **Group:** `status`
+- **Schema file:** `sanity/schemaTypes/dog.ts` (lines 140-146)
+- **Description:** "Keep this record in Sanity but do not display it on the public website"
+
+## Current Visibility Gap
+
+### What already works (pre-this-packet, already committed on this branch)
+- **Dedicated menu item:** "🚫 Hidden from Website" in Studio nav (studioStructure.ts lines 71-79)
+- Filters for `_type == "dog" && hideFromWebsite == true`
+- Staff can navigate to this list to see all hidden dogs
+
+### What was still missing (the gap)
+- In **All Dogs**, **Available Danes**, or any other dog list view, hidden dogs looked identical to visible dogs
+- No visual indicator on the list item preview
+- Staff browsing the main lists could not tell at a glance which dogs were hidden
+- The preview only showed `{statusEmoji} {name}` — no hidden state in title or subtitle
+- Staff had to click into each dog document to check the `hideFromWebsite` toggle
+
+## Relevant Studio Files
+
+| File | Purpose |
+|------|---------|
+| `sanity/schemaTypes/dog.ts` | Dog schema definition + preview |
+| `sanity/studioStructure.ts` | Studio navigation structure |
+| `sanity/sanity.config.ts` | Studio configuration |
+
+## Recommended Minimal Fix
+
+Add `hideFromWebsite` to the preview `select` and show a `🚫 HIDDEN` tag in the title + a "Hidden from website" subtitle. This makes hidden dogs visually distinct in every list view across the entire Studio, not just the dedicated menu.

--- a/_ttp/CR-79/CR-79-002-IMPLEMENTATION-PLAN.md
+++ b/_ttp/CR-79/CR-79-002-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,35 @@
+# CR-79-002: Implementation Plan
+
+## Exact UX Change
+
+Add a `🚫 HIDDEN` suffix to dog names and a "Hidden from website" subtitle in Sanity Studio list views for dogs where `hideFromWebsite === true`.
+
+**Before:** `🟢 Duke` (no indication of hidden state)
+**After:** `🟢 Duke 🚫 HIDDEN` with subtitle "Hidden from website"
+
+This applies in every Studio list that shows dog documents: Available Danes, All Dogs, Recently Adopted, Hidden from Website menu, etc.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `sanity/schemaTypes/dog.ts` | Add `hideFromWebsite` to preview select, append `🚫 HIDDEN` to title when true, add subtitle |
+
+**One file, one function, 4 lines changed.**
+
+## Why This Is the Minimum Viable Fix
+
+1. The dedicated "Hidden from Website" menu item already exists (committed earlier on this branch)
+2. The remaining gap is visibility within other lists — staff shouldn't have to navigate to the dedicated menu to know a dog is hidden
+3. Modifying the preview `prepare` function is the smallest change that provides universal visibility
+4. Uses the same emoji pattern (`🚫`) already established in the menu item title
+5. No new files, no new components, no new dependencies
+
+## Alternatives Considered and Rejected
+
+| Alternative | Reason Rejected |
+|-------------|----------------|
+| Custom list item component with colored badge | Over-engineered for a boolean indicator; emoji in title achieves same visibility with zero new components |
+| Separate "Hidden" column in list view | Sanity Studio document lists don't support custom columns without significant customization |
+| Document badge plugin | Requires installing @sanity/document-badges or custom plugin — too heavy for one boolean |
+| Only the dedicated menu (no preview change) | Doesn't solve the core visibility problem — staff in other lists still can't see hidden state |

--- a/_ttp/CR-79/CR-79-003-IMPLEMENTATION-REPORT.md
+++ b/_ttp/CR-79/CR-79-003-IMPLEMENTATION-REPORT.md
@@ -1,0 +1,72 @@
+# CR-79-003: Implementation Report
+
+## Exact Code Changed
+
+**File:** `sanity/schemaTypes/dog.ts`
+
+### Change 1: Added `hideFromWebsite` to preview select (line 301)
+```typescript
+// Before
+select: {
+  title: 'name',
+  status: 'status',
+  media: 'mainImage',
+},
+
+// After
+select: {
+  title: 'name',
+  status: 'status',
+  hideFromWebsite: 'hideFromWebsite',
+  media: 'mainImage',
+},
+```
+
+### Change 2: Added `hideFromWebsite` to prepare destructuring (line 305)
+```typescript
+// Before
+prepare({ title, status, media }: Record<string, any>) {
+
+// After
+prepare({ title, status, hideFromWebsite, media }: Record<string, any>) {
+```
+
+### Change 3: Added hidden tag and subtitle (lines 317-322)
+```typescript
+// Before
+return {
+  title: `${emoji} ${title}`,
+  media,
+}
+
+// After
+const hiddenTag = hideFromWebsite ? ' 🚫 HIDDEN' : ''
+
+return {
+  title: `${emoji} ${title}${hiddenTag}`,
+  subtitle: hideFromWebsite ? 'Hidden from website' : undefined,
+  media,
+}
+```
+
+## Before/After Behavior
+
+### Before
+- Dog list items showed: `🟢 Duke` (status emoji + name only)
+- No way to tell if a dog was hidden without clicking into the document
+- Hidden dogs were visually identical to visible dogs in every list
+
+### After
+- Hidden dogs show: `🟢 Duke 🚫 HIDDEN` with subtitle "Hidden from website"
+- Non-hidden dogs show: `🟢 Duke` (unchanged — no subtitle)
+- Hidden state is immediately visible in every Studio list: Available Danes, All Dogs, Hidden from Website, etc.
+
+## What Was Added
+- **Badge in list items:** Yes — `🚫 HIDDEN` appended to title
+- **Subtitle:** Yes — "Hidden from website" for hidden dogs
+- **Dedicated menu item:** Yes — already committed earlier on this branch (`f52f9f5`)
+- **Both badge and menu:** Yes
+
+## Limitations
+- The indicator uses emoji + text in the title field, not a colored badge component. This is because Sanity's default document list preview supports `title`, `subtitle`, and `media` — not custom badge components without a plugin.
+- The `🚫 HIDDEN` text appears at the end of the title, so very long dog names may push it offscreen in narrow viewports. In practice, dog names are short (1-3 words).

--- a/_ttp/CR-79/CR-79-004-VALIDATION-REPORT.md
+++ b/_ttp/CR-79/CR-79-004-VALIDATION-REPORT.md
@@ -1,0 +1,40 @@
+# CR-79-004: Validation Report
+
+## VAL-79-001: Hidden dog visible in Studio list
+**Method:** Code inspection of preview prepare function
+**Evidence:** When `hideFromWebsite === true`, title becomes `{emoji} {name} 🚫 HIDDEN` and subtitle becomes `"Hidden from website"`. This applies in every Studio list view (Available Danes, All Dogs, Hidden from Website menu, etc.).
+**Result:** PASS — hidden state is prominently displayed with both a title tag and subtitle
+
+## VAL-79-002: Non-hidden dog not falsely labeled
+**Method:** Code inspection of hiddenTag logic
+**Evidence:** `const hiddenTag = hideFromWebsite ? ' 🚫 HIDDEN' : ''` — when `hideFromWebsite` is `false` (default) or `undefined`, hiddenTag is empty string. Subtitle is `undefined` (not rendered). Title remains `{emoji} {name}` unchanged.
+**Result:** PASS — non-hidden dogs have no hidden indicator
+
+## VAL-79-003: Hidden Dogs menu returns only hidden dogs
+**Method:** Code inspection of studioStructure.ts line 77
+**Evidence:** Filter is `'_type == "dog" && hideFromWebsite == true'` — only dogs with `hideFromWebsite === true` appear in this list.
+**Result:** PASS — menu filter is exact boolean match
+
+## VAL-79-004: Normal editing workflow for dog entries still works
+**Method:** Code inspection of schema changes
+**Evidence:** The only change is to the `preview` block. No field definitions, validation rules, hidden conditions, or document behavior were modified. All 6 field groups (Basic Info, Status, Details, Medical, Photos, Adoption) are unchanged.
+**Result:** PASS — no editing workflow regression
+
+## VAL-79-005: No unrelated Studio navigation regressions
+**Method:** Code inspection of studioStructure.ts
+**Evidence:** The structure file was modified in the earlier commit (`f52f9f5`) to add the Hidden Dogs menu item. No other items were changed. The preview change is schema-level, not structure-level — it doesn't affect navigation.
+**Result:** PASS — all other menu items unchanged
+
+## Validation Summary
+| ID | Description | Result |
+|----|-------------|--------|
+| VAL-79-001 | Hidden dog visible | PASS |
+| VAL-79-002 | Non-hidden not falsely labeled | PASS |
+| VAL-79-003 | Hidden menu correct set | PASS |
+| VAL-79-004 | Editing workflow intact | PASS |
+| VAL-79-005 | No navigation regressions | PASS |
+
+**5/5 PASS**
+
+## Note on Validation Method
+These validations are based on code inspection. Full visual confirmation requires deploying the Studio and checking dog list views with actual data. The code logic is deterministic (boolean check → string append), so the behavior is verifiable from the code. A live-fire validation in the deployed Studio is recommended before closing CR-79.

--- a/_ttp/CR-79/CR-79-005-GO-LIVE-DECISION.md
+++ b/_ttp/CR-79/CR-79-005-GO-LIVE-DECISION.md
@@ -1,0 +1,28 @@
+# CR-79-005: Go-Live Decision
+
+## Decision: READY WITH RESTRICTIONS
+
+## Rationale
+The implementation is complete and all code-level validations pass. The change is minimal (one file, one function, 4 lines) and uses existing patterns (emoji + title string, same as status indicators).
+
+## Restrictions
+1. **Live-fire visual confirmation required** — a team member should open the deployed Studio and verify:
+   - A known hidden dog shows `🚫 HIDDEN` in the list view
+   - A known non-hidden dog does NOT show the hidden indicator
+   - The "Hidden from Website" menu item shows the correct filtered list
+2. **Deploy Studio after merge** — the preview change requires a Studio rebuild/redeploy to take effect
+
+## Classifications
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Usability impact | HIGH | Staff can now instantly identify hidden dogs in any list view — resolves the core CR-79 complaint |
+| Implementation complexity | LOW | 4 lines changed in one function, using existing patterns |
+| Blast radius | LOW | Preview-only change. No schema, query, validation, or navigation changes |
+| Reversibility | HIGH | Revert one commit to remove. No data migration, no schema change |
+
+## What This Does NOT Address
+- Why specific dogs are hidden (that's a content/operational decision)
+- Bulk hide/unhide operations (not in CR-79 scope)
+- CR-75 (separate CR, separate scope)
+- Any public website behavior changes (this is Studio-only)

--- a/sanity/schemaTypes/dog.ts
+++ b/sanity/schemaTypes/dog.ts
@@ -298,9 +298,10 @@ export const dog = defineType({
     select: {
       title: 'name',
       status: 'status',
+      hideFromWebsite: 'hideFromWebsite',
       media: 'mainImage',
     },
-    prepare({ title, status, media }: Record<string, any>) {
+    prepare({ title, status, hideFromWebsite, media }: Record<string, any>) {
       const statusEmoji: Record<string, string> = {
         available: '🟢',
         'under-evaluation': '🟠',
@@ -313,9 +314,11 @@ export const dog = defineType({
         'rainbow-bridge': '🌈',
       }
       const emoji = (status && statusEmoji[status]) || '❓'
+      const hiddenTag = hideFromWebsite ? ' 🚫 HIDDEN' : ''
 
       return {
-        title: `${emoji} ${title}`,
+        title: `${emoji} ${title}${hiddenTag}`,
+        subtitle: hideFromWebsite ? 'Hidden from website' : undefined,
         media,
       }
     },


### PR DESCRIPTION
## Summary
Makes hidden-from-website dog status visible to staff in Sanity Studio without requiring them to click into each document.

## Changes
1. **Hidden Dogs menu item** (commit f52f9f5, already on branch) — dedicated `🚫 Hidden from Website` nav item filtering `hideFromWebsite == true`
2. **List view indicator** (commit 6cc480f) — dogs with `hideFromWebsite=true` show `🚫 HIDDEN` in their title and "Hidden from website" subtitle in every Studio list

## Before / After
| View | Before | After |
|------|--------|-------|
| Any dog list | `🟢 Duke` (no hidden indicator) | `🟢 Duke 🚫 HIDDEN` + subtitle |
| Navigation | No Hidden Dogs menu | `🚫 Hidden from Website` menu item |

## Files changed
- `sanity/studioStructure.ts` — added Hidden Dogs menu item
- `sanity/schemaTypes/dog.ts` — added hideFromWebsite to preview select/prepare

## Scope
- Studio-only change. No public website behavior modified.
- No schema changes. No query changes. No field changes.
- Uses existing patterns (emoji in title, same as status indicators).

## Validation
- [x] Hidden dog shows `🚫 HIDDEN` in list (code-verified)
- [x] Non-hidden dog unchanged (code-verified)
- [x] Hidden Dogs menu filters correctly (code-verified)
- [x] Normal editing workflow unaffected
- [ ] Live-fire visual confirmation in deployed Studio (post-merge)

## Go-live decision
READY WITH RESTRICTIONS — live-fire visual confirmation recommended after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)