### PR TITLE
fix(CR-86): wire up submission filters + seed test data

### DIFF
--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import { createAdminSupabaseClient } from "@/lib/supabase/admin";
 import { getFormTypeLabel } from "@/lib/forms/registry";
+import SubmissionFilters from "./SubmissionFilters";
 
 export const dynamic = "force-dynamic";
 
@@ -50,6 +52,8 @@ interface Submission {
   applicant_profile: {
     form_type?: string;
     submitted_at?: string;
+    type?: string;
+    payload?: { application_type?: string };
     [key: string]: unknown;
   } | null;
   internal_flags: {
@@ -58,40 +62,80 @@ interface Submission {
   } | null;
 }
 
+/** Determine if a submission is adopt, foster, or other */
+function getApplicationCategory(s: Submission): "adopt" | "foster" | "other" {
+  // Check top-level type first (set by intake submit)
+  if (s.type === "adopt") return "adopt";
+  if (s.type === "foster") return "foster";
+  // Check applicant_profile.type (also set by intake)
+  const profileType = s.applicant_profile?.type;
+  if (profileType === "adopt") return "adopt";
+  if (profileType === "foster") return "foster";
+  // Check payload.application_type (set by full adoption-foster form)
+  const payload = s.applicant_profile?.payload;
+  const appType = payload?.application_type;
+  if (appType === "adopt" || appType === "both") return "adopt";
+  if (appType === "foster") return "foster";
+  // Check form_type string
+  const formType = s.internal_flags?.form_type ?? s.applicant_profile?.form_type;
+  if (typeof formType === "string" && formType.includes("adopt")) return "adopt";
+  if (typeof formType === "string" && formType.includes("foster")) return "foster";
+  return "other";
+}
+
 /* ── page ─────────────────────────────────────────────────────────────── */
 
-export default async function SubmissionsListPage() {
+interface PageProps {
+  searchParams: Promise<{ type?: string; status?: string }>;
+}
+
+export default async function SubmissionsListPage({ searchParams }: PageProps) {
+  const { type: typeFilter, status: statusFilter } = await searchParams;
   const supabase = createAdminSupabaseClient();
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("applications")
     .select(
       "id, type, status, submitted_at, applicant_name, applicant_email, applicant_profile, internal_flags"
     )
     .order("submitted_at", { ascending: false })
-    .limit(100);
+    .limit(200);
+
+  if (statusFilter && statusFilter !== "all") {
+    query = query.eq("status", statusFilter);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     return (
       <div className="bg-red-50 border border-red-200 rounded-md p-4">
-        <p className="text-red-800 text-sm">
-          Failed to load submissions: {error.message}
-        </p>
+        <p className="text-red-800 text-sm">Failed to load submissions: {error.message}</p>
       </div>
     );
   }
 
-  const submissions: Submission[] = data ?? [];
+  let submissions: Submission[] = data ?? [];
+
+  // Type filter (application category is inside JSONB, filtered client-side)
+  if (typeFilter && typeFilter !== "all") {
+    submissions = submissions.filter((s) => getApplicationCategory(s) === typeFilter);
+  }
 
   return (
     <div>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">
-        Form Submissions
-      </h1>
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-2xl font-bold text-gray-900">Form Submissions</h1>
+        <span className="text-sm text-gray-500">{submissions.length} results</span>
+      </div>
+
+      <Suspense>
+        <SubmissionFilters />
+      </Suspense>
 
       {submissions.length === 0 ? (
         <div className="bg-white rounded-lg shadow p-8 text-center">
-          <p className="text-gray-500">No submissions yet.</p>
+          <p className="text-gray-500">No submissions match the current filters.</p>
         </div>
       ) : (
         <div className="bg-white rounded-lg shadow overflow-hidden">
@@ -99,57 +143,39 @@ export default async function SubmissionsListPage() {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Name
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Email
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Form Type
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Date
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                   <th className="px-4 py-3" />
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
                 {submissions.map((s) => {
-                  const formType =
-                    s.internal_flags?.form_type ??
-                    s.applicant_profile?.form_type ??
-                    s.type;
-                  const dateStr =
-                    s.applicant_profile?.submitted_at ??
-                    s.submitted_at;
+                  const formType = s.internal_flags?.form_type ?? s.applicant_profile?.form_type ?? s.type;
+                  const dateStr = s.applicant_profile?.submitted_at ?? s.submitted_at;
+                  const cat = getApplicationCategory(s);
+                  const catLabel = cat === "adopt" ? "Adoption" : cat === "foster" ? "Foster" : getFormTypeLabel(formType as string);
 
                   return (
                     <tr key={s.id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-4 py-3 text-sm text-gray-900">
-                        {s.applicant_name || "—"}
+                      <td className="px-4 py-3 text-sm text-gray-900">{s.applicant_name || "—"}</td>
+                      <td className="px-4 py-3 text-sm text-gray-600">{s.applicant_email || "—"}</td>
+                      <td className="px-4 py-3 text-sm">
+                        <span className={`inline-block text-xs font-medium px-2 py-0.5 rounded-full ${
+                          cat === "adopt" ? "bg-emerald-100 text-emerald-800" :
+                          cat === "foster" ? "bg-purple-100 text-purple-800" :
+                          "bg-gray-100 text-gray-700"
+                        }`}>
+                          {catLabel}
+                        </span>
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">
-                        {s.applicant_email || "—"}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-gray-600">
-                        {getFormTypeLabel(formType)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
-                        {formatDate(dateStr as string | null)}
-                      </td>
-                      <td className="px-4 py-3">
-                        {statusBadge(s.status)}
-                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">{formatDate(dateStr as string | null)}</td>
+                      <td className="px-4 py-3">{statusBadge(s.status)}</td>
                       <td className="px-4 py-3 text-right">
-                        <Link
-                          href={`/admin/submissions/${s.id}`}
-                          className="text-sm text-blue-600 hover:text-blue-800 font-medium"
-                        >
-                          View
+                        <Link href={`/admin/submissions/${s.id}`} className="text-sm text-blue-600 hover:text-blue-800 font-medium">
+                          Review →
                         </Link>
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary

The type-filtered tabs from CR-86 were lost during the PR #88 merge. This commit wires them up properly.

## What was missing
- `SubmissionFilters` component was created but never imported
- `searchParams` was not being read
- `getApplicationCategory()` filter function was not present
- Category badges (Adoption/Foster/Other) were not rendering

## Also done
- Seeded 3 test applications (2 adoption, 1 foster) so the filtered views have data to display

🤖 Generated with [Claude Code](https://claude.com/claude-code)