### PR TITLE
feat(schema): add Dog ID and Intake ID fields (CR-90)

### DIFF
--- a/sanity/schemaTypes/dog.ts
+++ b/sanity/schemaTypes/dog.ts
@@ -22,6 +22,26 @@ export const dog = defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'dogId',
+      title: 'Dog ID',
+      type: 'string',
+      group: 'basic',
+      description: 'Format: RMGDRI-YYYY-### (e.g., RMGDRI-2026-001)',
+      placeholder: 'RMGDRI-2026-001',
+      validation: (Rule) =>
+        Rule.regex(
+          /^RMGDRI-\d{4}-\d{3}$/,
+          'Must be in RMGDRI-YYYY-### format (e.g., RMGDRI-2026-001)'
+        ),
+    }),
+    defineField({
+      name: 'intakeId',
+      title: 'Intake ID',
+      type: 'string',
+      group: 'basic',
+      description: 'Internal intake tracking identifier',
+    }),
+    defineField({
       name: 'slug',
       title: 'URL Slug',
       type: 'slug',
@@ -298,10 +318,11 @@ export const dog = defineType({
     select: {
       title: 'name',
       status: 'status',
+      dogId: 'dogId',
       hideFromWebsite: 'hideFromWebsite',
       media: 'mainImage',
     },
-    prepare({ title, status, hideFromWebsite, media }: Record<string, any>) {
+    prepare({ title, status, dogId, hideFromWebsite, media }: Record<string, any>) {
       const statusEmoji: Record<string, string> = {
         available: '🟢',
         'under-evaluation': '🟠',
@@ -315,10 +336,11 @@ export const dog = defineType({
       }
       const emoji = (status && statusEmoji[status]) || '❓'
       const hiddenTag = hideFromWebsite ? ' 🚫 HIDDEN' : ''
+      const idTag = dogId ? ` [${dogId}]` : ''
 
       return {
         title: `${emoji} ${title}${hiddenTag}`,
-        subtitle: hideFromWebsite ? 'Hidden from website' : undefined,
+        subtitle: hideFromWebsite ? 'Hidden from website' : (dogId || undefined),
         media,
       }
     },


### PR DESCRIPTION
## Summary
- Adds `dogId` field (format `RMGDRI-YYYY-###` with regex validation) to Basic Info tab, directly under Dog Name
- Adds `intakeId` field (free-text) to Basic Info tab, directly under Dog ID
- Dog ID shown in Studio list view subtitle for quick identification
- Both fields optional — no impact on existing dog records

## CR-90
**Requester:** Lori (ilori-beep)  
**Priority:** Urgent — blocks operations  
**Issue:** #90

## Test plan
- [ ] Open Sanity Studio → allDogs → any dog record
- [ ] Verify Dog ID and Intake ID fields appear on Basic Info tab under Dog Name
- [ ] Enter a valid Dog ID (e.g., `RMGDRI-2026-001`) — should accept
- [ ] Enter an invalid Dog ID (e.g., `RMGDRI-26-1`) — should show validation error
- [ ] Verify Dog ID appears in the Studio list view subtitle
- [ ] Verify existing dog records load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)