### PR TITLE
fix: respect image hotspot/crop on homepage & adoption successes (CR-58)

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { client } from '@/lib/sanity/client'
 import Hero from '@/components/Hero'
 import { getYears } from '@/lib/adoption-successes'
+import { buildImageUrl, SanityImageField } from '@/lib/sanity/image'
 
 export const revalidate = 60 // revalidate every 60 seconds
 
@@ -11,7 +12,7 @@ const HISTORICAL_ADOPTION_COUNT = 2323
 type Dog = {
   name: string
   slug: string
-  mainImage?: { asset: { url: string } }
+  mainImage?: SanityImageField
 }
 
 async function getFeaturedDogs() {
@@ -19,7 +20,7 @@ async function getFeaturedDogs() {
     `*[_type == "dog" && status in ["available", "pending", "foster-needed", "waiting-transport", "under-evaluation"] && hideFromWebsite != true] | order(_createdAt desc) [0...4] {
       name,
       "slug": slug.current,
-      mainImage { asset-> { url } }
+      mainImage { "assetRef": asset._ref, hotspot, crop }
     }`
   )
 }
@@ -100,9 +101,9 @@ export default async function Home() {
                 <div key={dog.slug} className="group">
                   <div className="bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
                     <div className="relative aspect-square w-full overflow-hidden">
-                      {dog.mainImage?.asset?.url ? (
+                      {dog.mainImage?.assetRef ? (
                         <img
-                          src={dog.mainImage.asset.url}
+                          src={buildImageUrl(dog.mainImage, { width: 500, height: 500 }) || ''}
                           alt={dog.name}
                           className="w-full h-full object-cover object-center group-hover:scale-110 transition-transform duration-500"
                         />

--- a/src/lib/adoption-successes.ts
+++ b/src/lib/adoption-successes.ts
@@ -1,5 +1,6 @@
 import successesData from '@/data/adoption-successes/successes.normalized.json'
 import { sanityClient } from '@/lib/sanity/client'
+import { buildImageUrl } from '@/lib/sanity/image'
 
 export type AdoptionSuccessRecord = {
   id_number: string
@@ -36,14 +37,20 @@ async function getSanityAdopted(): Promise<AdoptionSuccessRecord[]> {
         adoptionDate,
         adoptionYear,
         adoptionStory,
-        "mainImageUrl": mainImage.asset->url,
-        "adoptionHeroUrl": adoptionHeroImage.asset->url
+        "mainImage": mainImage { "assetRef": asset._ref, hotspot, crop },
+        "adoptionHeroImage": adoptionHeroImage { "assetRef": asset._ref, hotspot, crop }
       }
     `, {}, { next: { revalidate: 60 } })
 
     return dogs.map((dog: any) => {
       const year = parseInt(dog.adoptionYear, 10)
       const slug = `${dog.slug}-${year}`
+      // Pre-bake hotspot/crop into CDN URL so downstream components
+      // get a correctly cropped image without needing structured data
+      const heroImage = dog.adoptionHeroImage || dog.mainImage
+      const heroUrl = heroImage
+        ? buildImageUrl(heroImage, { width: 800, height: 800 })
+        : ''
       return {
         id_number: dog._id,
         name: dog.name,
@@ -52,7 +59,7 @@ async function getSanityAdopted(): Promise<AdoptionSuccessRecord[]> {
         adoption_year: year,
         slug,
         title: dog.name,
-        hero_image_ref: dog.adoptionHeroUrl || dog.mainImageUrl || '',
+        hero_image_ref: heroUrl || '',
         blog_text: dog.adoptionStory || dog.shortDescription || '',
         blog_url: `/blog/${slug}`,
         original_slug: slug,


### PR DESCRIPTION
## Summary
- **Homepage**: GROQ query now fetches `{ assetRef, hotspot, crop }` instead of `asset->{ url }`. Renders via `buildImageUrl()` so Sanity hotspot/crop selections are baked into the CDN URL server-side.
- **Adoption successes**: GROQ query now fetches structured image fields for both `mainImage` and `adoptionHeroImage`. Hotspot/crop is pre-baked into the CDN URL at fetch time — no changes needed to downstream year-grid or detail-page components.

## Root cause
PR #62 fixed `available-danes/` pages but these two locations were missed. Both used `asset->url` (raw, uncropped) instead of the structured image field needed by `buildImageUrl()`.

## Pages affected
| Page | Before | After |
|------|--------|-------|
| Homepage (featured danes) | Raw asset URL, hotspot ignored | `buildImageUrl()` with crop |
| Adoption success grid | Raw asset URL, hotspot ignored | Pre-baked CDN URL with crop |
| Adoption success detail | Raw asset URL, hotspot ignored | Pre-baked CDN URL with crop |

## Test plan
- [ ] Homepage: verify featured dog images respect their Sanity hotspot selections
- [ ] `/adoption-successes/2026` grid: verify adopted dog cards show correctly cropped images
- [ ] `/adoption-successes/2026/[slug]` detail: verify hero image respects hotspot
- [ ] Compare a dog with a known hotspot selection against the live site — crop should visibly change
- [ ] Verify dogs without hotspot set still display correctly (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)