### PR TITLE
fix(schema): Intake ID format validation — TR/OS prefix (CR-93)

### DIFF
--- a/sanity/schemaTypes/dog.ts
+++ b/sanity/schemaTypes/dog.ts
@@ -39,7 +39,13 @@ export const dog = defineType({
       title: 'Intake ID',
       type: 'string',
       group: 'basic',
-      description: 'Internal intake tracking identifier',
+      description: 'Transfer: TR-YYYY-### | Owner Surrender: OS-YYYY-### (e.g., TR-2026-001 or OS-2026-015)',
+      placeholder: 'TR-2026-001',
+      validation: (Rule) =>
+        Rule.regex(
+          /^(TR|OS)-\d{4}-\d{3}$/,
+          'Must be TR-YYYY-### (Transfer) or OS-YYYY-### (Owner Surrender)'
+        ),
     }),
     defineField({
       name: 'slug',


### PR DESCRIPTION
## Summary
- Intake ID field now validates format: `TR-YYYY-###` (Transfer) or `OS-YYYY-###` (Owner Surrender)
- Description updated to show both formats with examples
- Placeholder set to `TR-2026-001`

## CR-93
**Requester:** Lori (via Ray)  
**Priority:** Urgent — blocks operations

## Test plan
- [ ] Open Studio → allDogs → any dog → Basic Info tab
- [ ] Enter `TR-2026-001` — should accept
- [ ] Enter `OS-2026-015` — should accept
- [ ] Enter `XX-2026-001` — should reject with validation error
- [ ] Enter `TR2026001` (no dashes) — should reject
- [ ] Leave blank — should accept (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)