### PR TITLE
feat(schema): auto-prefix Dog ID with RMGDRI- in Studio (CR-90)

### DIFF
--- a/sanity/components/PrefixedInput.tsx
+++ b/sanity/components/PrefixedInput.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { StringInputProps, set, unset } from 'sanity'
+import { TextInput, Flex, Box, Text } from '@sanity/ui'
+
+/**
+ * A string input that displays a fixed prefix (e.g. "RMGDRI-").
+ * The stored value includes the prefix, but the user only types the suffix.
+ */
+export function PrefixedInput(props: StringInputProps & { prefix?: string }) {
+  const { onChange, value = '', elementProps } = props
+  const prefix = props.prefix || 'RMGDRI-'
+
+  // Strip prefix for display in the editable portion
+  const suffix = value.startsWith(prefix) ? value.slice(prefix.length) : value
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newSuffix = event.currentTarget.value
+      if (newSuffix) {
+        onChange(set(`${prefix}${newSuffix}`))
+      } else {
+        onChange(unset())
+      }
+    },
+    [onChange, prefix],
+  )
+
+  return (
+    <Flex align="center" gap={1}>
+      <Box
+        paddingX={3}
+        paddingY={2}
+        style={{
+          background: 'var(--card-muted-bg-color)',
+          borderRadius: '4px 0 0 4px',
+          border: '1px solid var(--card-border-color)',
+          borderRight: 'none',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <Text size={1} weight="semibold" muted>
+          {prefix}
+        </Text>
+      </Box>
+      <Box flex={1}>
+        <TextInput
+          {...elementProps}
+          value={suffix}
+          onChange={handleChange}
+          placeholder="YYYY-###"
+          style={{ borderRadius: '0 4px 4px 0' }}
+        />
+      </Box>
+    </Flex>
+  )
+}

--- a/sanity/schemaTypes/dog.ts
+++ b/sanity/schemaTypes/dog.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from 'sanity'
+import { PrefixedInput } from '../components/PrefixedInput'
 
 export const dog = defineType({
   name: 'dog',
@@ -26,8 +27,10 @@ export const dog = defineType({
       title: 'Dog ID',
       type: 'string',
       group: 'basic',
-      description: 'Format: RMGDRI-YYYY-### (e.g., RMGDRI-2026-001)',
-      placeholder: 'RMGDRI-2026-001',
+      description: 'Enter year and number only — "RMGDRI-" is added automatically (e.g., 2026-001)',
+      components: {
+        input: (props) => PrefixedInput({ ...props, prefix: 'RMGDRI-' }),
+      },
       validation: (Rule) =>
         Rule.regex(
           /^RMGDRI-\d{4}-\d{3}$/,


### PR DESCRIPTION
## Summary
- New `PrefixedInput` component displays "RMGDRI-" as a locked, non-editable prefix
- Editor only types `YYYY-###` (e.g., `2026-001`) — stored value is `RMGDRI-2026-001`
- Regex validation unchanged — full format still enforced

## CR-90 (follow-up)
**Requester:** Lori via Ray  
**Priority:** Urgent  
**Issue:** #90

## Test plan
- [ ] Open Studio → allDogs → any dog → Basic Info
- [ ] Verify "RMGDRI-" appears as a non-editable prefix before the input
- [ ] Type `2026-001` — should save as `RMGDRI-2026-001`
- [ ] Type invalid suffix like `26-1` — validation should reject
- [ ] Clear field — should accept (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)