### PR TITLE
feat(CR-112): volunteer satisfaction survey + dashboard + email

### DIFF
--- a/src/app/(main)/volunteer-survey/VolunteerSurveyForm.tsx
+++ b/src/app/(main)/volunteer-survey/VolunteerSurveyForm.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+
+const RATING_QUESTIONS = [
+  { key: "communication", label: "How clear and timely is communication from RMGDRI leadership?" },
+  { key: "scheduling", label: "How well-organized is scheduling and coordination for your role?" },
+  { key: "leadership_support", label: "How supported do you feel by RMGDRI leadership?" },
+  { key: "tools_preparedness", label: "How prepared and equipped do you feel to perform your volunteer duties?" },
+  { key: "event_experience", label: "How would you rate your experience at RMGDRI events (if applicable)?" },
+  { key: "raise_concerns", label: "How comfortable are you raising concerns or giving feedback?" },
+  { key: "valued", label: "How valued do you feel as a volunteer?" },
+  { key: "overall", label: "Overall, how satisfied are you with your volunteer experience at RMGDRI?" },
+];
+
+const RATING_OPTIONS = [
+  { value: "1", label: "1 — Poor" },
+  { value: "2", label: "2 — Fair" },
+  { value: "3", label: "3 — Good" },
+  { value: "4", label: "4 — Very Good" },
+  { value: "5", label: "5 — Excellent" },
+];
+
+const ROLE_OPTIONS = [
+  "Foster",
+  "Transporter",
+  "Event Volunteer",
+  "Application Processor",
+  "Home Check Processor",
+  "Follow-up Specialist",
+  "Social Media",
+  "Fundraising",
+  "Board Member",
+  "Staff",
+  "Other",
+];
+
+export default function VolunteerSurveyForm() {
+  const [ratings, setRatings] = useState<Record<string, string>>({});
+  const [role, setRole] = useState("");
+  const [bestPart, setBestPart] = useState("");
+  const [improve, setImprove] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  function setRating(key: string, val: string) {
+    setRatings((prev) => ({ ...prev, [key]: val }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setResult(null);
+
+    // Validate — all ratings required
+    const missing = RATING_QUESTIONS.filter((q) => !ratings[q.key]);
+    if (missing.length > 0) {
+      setResult({
+        ok: false,
+        message: `Please rate all questions. Missing: ${missing.map((q) => q.label.split("?")[0]).join(", ")}`,
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/forms/volunteer-survey/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ratings,
+          role: role || "Prefer not to say",
+          best_part: bestPart,
+          improvement_suggestions: improve,
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (res.ok) {
+        setResult({
+          ok: true,
+          message: "Thank you for your feedback! Your anonymous response has been recorded.",
+        });
+      } else {
+        setResult({ ok: false, message: data?.error || `Error ${res.status}` });
+      }
+    } catch {
+      setResult({ ok: false, message: "Network error — please try again." });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (result?.ok) {
+    return (
+      <div className="max-w-2xl mx-auto px-6 pt-12">
+        <div className="bg-emerald-50 border-2 border-emerald-500 rounded-xl p-8 text-center">
+          <div className="text-5xl mb-4">🎉</div>
+          <h2 className="text-2xl font-bold text-emerald-700 mb-3">Thank You!</h2>
+          <p className="text-gray-700">{result.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 pt-10">
+      <div className="bg-teal-50 border border-teal-200 rounded-xl p-5 mb-8 text-sm text-gray-700">
+        <p className="font-semibold text-teal-800 mb-1">This survey is completely anonymous.</p>
+        <p>No name, email, or identifying information is collected. Your honest feedback helps us improve.</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        {/* Optional role */}
+        <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <label className="block text-sm font-semibold text-gray-700 mb-2">
+            Your primary volunteer role <span className="text-gray-400 font-normal">(optional)</span>
+          </label>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 outline-none"
+          >
+            <option value="">Prefer not to say</option>
+            {ROLE_OPTIONS.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Rating questions */}
+        {RATING_QUESTIONS.map((q) => (
+          <div key={q.key} className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+            <p className="text-sm font-semibold text-gray-800 mb-3">
+              {q.label} <span className="text-red-500">*</span>
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {RATING_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`flex items-center gap-2 cursor-pointer px-4 py-2 rounded-lg border transition-colors text-sm ${
+                    ratings[q.key] === opt.value
+                      ? "border-teal-500 bg-teal-50 text-teal-700 font-semibold"
+                      : "border-gray-300 bg-white hover:bg-gray-50 text-gray-700"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name={q.key}
+                    value={opt.value}
+                    checked={ratings[q.key] === opt.value}
+                    onChange={() => setRating(q.key, opt.value)}
+                    className="accent-teal-600"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Free text — best part */}
+        <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <label className="block text-sm font-semibold text-gray-700 mb-2">
+            What do you enjoy most about volunteering with RMGDRI?
+          </label>
+          <textarea
+            value={bestPart}
+            onChange={(e) => setBestPart(e.target.value)}
+            rows={3}
+            placeholder="Share what's working well..."
+            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 outline-none"
+          />
+        </div>
+
+        {/* Free text — improvements */}
+        <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <label className="block text-sm font-semibold text-gray-700 mb-2">
+            What could we do to improve the volunteer experience?
+          </label>
+          <textarea
+            value={improve}
+            onChange={(e) => setImprove(e.target.value)}
+            rows={3}
+            placeholder="Suggestions, concerns, or ideas..."
+            className="w-full border border-gray-300 rounded-lg px-4 py-3 text-gray-900 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 outline-none"
+          />
+        </div>
+
+        {/* Feedback */}
+        <div id="survey-feedback">
+          {result && !result.ok && (
+            <div className="bg-red-50 border-2 border-red-400 rounded-xl p-5 text-red-700 text-sm">
+              {result.message}
+            </div>
+          )}
+        </div>
+
+        {/* Submit */}
+        <div className="text-center pt-2 pb-8">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="bg-teal-600 hover:bg-teal-700 disabled:bg-gray-400 text-white px-10 py-4 rounded-lg text-lg font-semibold transition-colors shadow-lg"
+          >
+            {submitting ? "Submitting..." : "Submit Anonymous Feedback"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(main)/volunteer-survey/page.tsx
+++ b/src/app/(main)/volunteer-survey/page.tsx
@@ -1,0 +1,23 @@
+import VolunteerSurveyForm from "./VolunteerSurveyForm";
+
+export const metadata = {
+  title: "Volunteer Satisfaction Survey | RMGDRI",
+  description:
+    "Share your anonymous feedback to help us improve the volunteer experience at Rocky Mountain Great Dane Rescue.",
+};
+
+export default function VolunteerSurveyPage() {
+  return (
+    <main className="pb-20 bg-white">
+      <section className="bg-gradient-to-r from-teal-600 to-emerald-600 text-white py-14">
+        <div className="max-w-3xl mx-auto px-4 text-center">
+          <h1 className="text-4xl font-bold mb-3">Volunteer Satisfaction Survey</h1>
+          <p className="text-teal-100 text-lg">
+            Your feedback is anonymous and helps us improve the volunteer experience.
+          </p>
+        </div>
+      </section>
+      <VolunteerSurveyForm />
+    </main>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -13,9 +13,16 @@ export default function AdminLayout({
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-gray-900 text-white px-6 py-3 flex items-center justify-between">
-        <a href="/admin/submissions" className="font-semibold text-lg hover:text-gray-200 transition-colors">
-          RMGDRI Admin
-        </a>
+        <div className="flex items-center gap-6">
+          <a href="/admin/submissions" className="font-semibold text-lg hover:text-gray-200 transition-colors">
+            RMGDRI Admin
+          </a>
+          <nav className="flex gap-4 text-sm">
+            <a href="/admin/submissions" className="text-gray-300 hover:text-white transition-colors">Applications</a>
+            <a href="/admin/survey-dashboard" className="text-gray-300 hover:text-white transition-colors">Surveys</a>
+            <a href="/admin/intent" className="text-gray-300 hover:text-white transition-colors">Intent</a>
+          </nav>
+        </div>
         <form action="/api/admin/logout" method="POST">
           <button
             type="submit"

--- a/src/app/admin/survey-dashboard/page.tsx
+++ b/src/app/admin/survey-dashboard/page.tsx
@@ -1,0 +1,267 @@
+import { createAdminSupabaseClient } from "@/lib/supabase/admin";
+
+export const dynamic = "force-dynamic";
+
+const RATING_LABELS: Record<string, string> = {
+  communication: "Communication",
+  scheduling: "Scheduling",
+  leadership_support: "Leadership Support",
+  tools_preparedness: "Tools & Preparedness",
+  event_experience: "Event Experience",
+  raise_concerns: "Comfort Raising Concerns",
+  valued: "Feeling Valued",
+  overall: "Overall Satisfaction",
+};
+
+function ratingBar(avg: number) {
+  const pct = (avg / 5) * 100;
+  const color =
+    avg >= 4 ? "bg-emerald-500" : avg >= 3 ? "bg-yellow-500" : "bg-red-500";
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex-1 bg-gray-200 rounded-full h-3">
+        <div
+          className={`h-3 rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-sm font-semibold text-gray-700 w-10 text-right">
+        {avg.toFixed(1)}
+      </span>
+    </div>
+  );
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface SurveyResponse {
+  id: string;
+  submitted_at: string | null;
+  applicant_profile: {
+    payload?: {
+      ratings?: Record<string, string>;
+      role?: string;
+      best_part?: string;
+      improvement_suggestions?: string;
+      average_score?: string;
+    };
+  } | null;
+}
+
+export default async function SurveyDashboardPage() {
+  const supabase = createAdminSupabaseClient();
+
+  const { data, error } = await supabase
+    .from("applications")
+    .select("id, submitted_at, applicant_profile")
+    .eq("type", "volunteer_survey")
+    .order("submitted_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-md p-4">
+        <p className="text-red-800 text-sm">Failed to load surveys: {error.message}</p>
+      </div>
+    );
+  }
+
+  const responses: SurveyResponse[] = data ?? [];
+
+  // Compute aggregates
+  const ratingKeys = Object.keys(RATING_LABELS);
+  const aggregates: Record<string, { sum: number; count: number }> = {};
+  for (const key of ratingKeys) {
+    aggregates[key] = { sum: 0, count: 0 };
+  }
+
+  const roleCounts: Record<string, number> = {};
+
+  for (const r of responses) {
+    const payload = r.applicant_profile?.payload;
+    if (!payload?.ratings) continue;
+    for (const key of ratingKeys) {
+      const val = Number(payload.ratings[key] || 0);
+      if (val > 0) {
+        aggregates[key].sum += val;
+        aggregates[key].count += 1;
+      }
+    }
+    const role = payload.role || "Not specified";
+    roleCounts[role] = (roleCounts[role] || 0) + 1;
+  }
+
+  const overallAvg =
+    aggregates.overall.count > 0
+      ? aggregates.overall.sum / aggregates.overall.count
+      : 0;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">
+        Volunteer Satisfaction Survey Dashboard
+      </h1>
+
+      {responses.length === 0 ? (
+        <div className="bg-white rounded-lg shadow p-8 text-center">
+          <p className="text-gray-500">No survey responses yet.</p>
+          <p className="text-sm text-gray-400 mt-2">
+            Share the survey at: /volunteer-survey
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+            <div className="bg-white rounded-lg shadow p-5">
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                Total Responses
+              </p>
+              <p className="text-3xl font-bold text-gray-900">
+                {responses.length}
+              </p>
+            </div>
+            <div className="bg-white rounded-lg shadow p-5">
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                Overall Satisfaction
+              </p>
+              <p className="text-3xl font-bold text-gray-900">
+                {overallAvg > 0 ? `${overallAvg.toFixed(1)}/5` : "—"}
+              </p>
+            </div>
+            <div className="bg-white rounded-lg shadow p-5">
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                Role Breakdown
+              </p>
+              <div className="text-sm text-gray-700 space-y-1 mt-1">
+                {Object.entries(roleCounts)
+                  .sort((a, b) => b[1] - a[1])
+                  .slice(0, 4)
+                  .map(([role, count]) => (
+                    <div key={role} className="flex justify-between">
+                      <span>{role}</span>
+                      <span className="font-semibold">{count}</span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Aggregate ratings */}
+          <div className="bg-white rounded-lg shadow p-6 mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Average Ratings ({responses.length} responses)
+            </h2>
+            <div className="space-y-3">
+              {ratingKeys.map((key) => {
+                const avg =
+                  aggregates[key].count > 0
+                    ? aggregates[key].sum / aggregates[key].count
+                    : 0;
+                return (
+                  <div key={key}>
+                    <div className="flex justify-between text-sm mb-1">
+                      <span className="text-gray-600">{RATING_LABELS[key]}</span>
+                      <span className="text-gray-400 text-xs">
+                        {aggregates[key].count} responses
+                      </span>
+                    </div>
+                    {ratingBar(avg)}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Individual responses */}
+          <div className="bg-white rounded-lg shadow p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              Individual Responses
+            </h2>
+            <div className="space-y-4">
+              {responses.map((r) => {
+                const payload = r.applicant_profile?.payload;
+                if (!payload) return null;
+                const avg = payload.average_score || "—";
+                return (
+                  <div
+                    key={r.id}
+                    className="border border-gray-200 rounded-lg p-4"
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <div>
+                        <span className="text-sm font-semibold text-gray-800">
+                          {payload.role || "Anonymous"}
+                        </span>
+                        <span className="text-xs text-gray-400 ml-2">
+                          Avg: {avg}/5
+                        </span>
+                      </div>
+                      <span className="text-xs text-gray-400">
+                        {formatDate(r.submitted_at)}
+                      </span>
+                    </div>
+
+                    {/* Compact ratings */}
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {ratingKeys.map((key) => {
+                        const val = Number(payload.ratings?.[key] || 0);
+                        const bg =
+                          val >= 4
+                            ? "bg-emerald-100 text-emerald-800"
+                            : val >= 3
+                            ? "bg-yellow-100 text-yellow-800"
+                            : val > 0
+                            ? "bg-red-100 text-red-800"
+                            : "bg-gray-100 text-gray-500";
+                        return (
+                          <span
+                            key={key}
+                            className={`text-xs px-2 py-0.5 rounded-full font-medium ${bg}`}
+                            title={RATING_LABELS[key]}
+                          >
+                            {RATING_LABELS[key].split(" ")[0]}: {val || "—"}
+                          </span>
+                        );
+                      })}
+                    </div>
+
+                    {payload.best_part && (
+                      <div className="text-sm text-gray-700 mb-2">
+                        <span className="font-medium text-gray-500">
+                          Best part:{" "}
+                        </span>
+                        {payload.best_part}
+                      </div>
+                    )}
+                    {payload.improvement_suggestions && (
+                      <div className="text-sm text-gray-700">
+                        <span className="font-medium text-gray-500">
+                          Improve:{" "}
+                        </span>
+                        {payload.improvement_suggestions}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/forms/volunteer-survey/submit/route.ts
+++ b/src/app/api/forms/volunteer-survey/submit/route.ts
@@ -1,0 +1,212 @@
+/**
+ * POST /api/forms/volunteer-survey/submit
+ *
+ * Anonymous Volunteer Satisfaction Survey submission handler.
+ * - Stores response in Supabase applications table (type: "volunteer_survey")
+ * - Sends email notification to Lori@rmgreatdane.org
+ * - No identity fields collected — anonymous by design
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export const runtime = "nodejs";
+
+/* ── Rate limiter ── */
+const hits = new Map<string, number[]>();
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const log = (hits.get(ip) ?? []).filter((t) => now - t < 60_000);
+  log.push(now);
+  hits.set(ip, log);
+  return log.length > 5;
+}
+
+/* ── Email helper ── */
+async function sendEmailNotification(data: Record<string, unknown>) {
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) {
+    console.warn("[volunteer-survey] RESEND_API_KEY not set — skipping email");
+    return;
+  }
+
+  const ratings = (data.ratings ?? {}) as Record<string, string>;
+  const ratingLabels: Record<string, string> = {
+    communication: "Communication clarity",
+    scheduling: "Scheduling & coordination",
+    leadership_support: "Leadership support",
+    tools_preparedness: "Tools & preparedness",
+    event_experience: "Event experience",
+    raise_concerns: "Comfort raising concerns",
+    valued: "Feeling valued",
+    overall: "Overall satisfaction",
+  };
+
+  const ratingLines = Object.entries(ratingLabels)
+    .map(([key, label]) => `${label}: ${ratings[key] || "—"}/5`)
+    .join("\n");
+
+  const avgScore =
+    Object.values(ratings).length > 0
+      ? (
+          Object.values(ratings).reduce((s, v) => s + Number(v || 0), 0) /
+          Object.values(ratings).length
+        ).toFixed(1)
+      : "N/A";
+
+  const body = `New Volunteer Satisfaction Survey Response
+
+Role: ${data.role || "Not specified"}
+Average Score: ${avgScore}/5
+Submitted: ${new Date().toLocaleString("en-US", { timeZone: "America/Denver" })}
+
+--- Ratings ---
+${ratingLines}
+
+--- What they enjoy most ---
+${data.best_part || "(no response)"}
+
+--- Improvement suggestions ---
+${data.improvement_suggestions || "(no response)"}
+`;
+
+  try {
+    const res = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${resendKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: process.env.RESEND_FROM_EMAIL || "RMGDRI Surveys <surveys@rmgreatdane.org>",
+        to: ["Lori@rmgreatdane.org"],
+        subject: `Volunteer Survey Response — ${avgScore}/5 avg (${data.role || "Anonymous"})`,
+        text: body,
+      }),
+    });
+    if (!res.ok) {
+      const err = await res.text();
+      console.error("[volunteer-survey] Email send failed:", res.status, err);
+    }
+  } catch (err) {
+    console.error("[volunteer-survey] Email send error:", err);
+  }
+}
+
+/* ── Handler ── */
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { ok: false, error: "Too many submissions — please wait." },
+      { status: 429 }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON" },
+      { status: 400 }
+    );
+  }
+
+  // Validate ratings
+  const ratings = body.ratings as Record<string, string> | undefined;
+  if (!ratings || typeof ratings !== "object") {
+    return NextResponse.json(
+      { ok: false, error: "Ratings are required" },
+      { status: 400 }
+    );
+  }
+
+  const requiredKeys = [
+    "communication",
+    "scheduling",
+    "leadership_support",
+    "tools_preparedness",
+    "event_experience",
+    "raise_concerns",
+    "valued",
+    "overall",
+  ];
+  const missing = requiredKeys.filter(
+    (k) => !ratings[k] || !["1", "2", "3", "4", "5"].includes(ratings[k])
+  );
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { ok: false, error: `Missing or invalid ratings: ${missing.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  // Persist to Supabase
+  const url = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    return NextResponse.json(
+      { ok: false, error: "Database not configured" },
+      { status: 503 }
+    );
+  }
+
+  const supabase = createClient(url, serviceKey, {
+    auth: { persistSession: false },
+  });
+
+  const avgScore =
+    Object.values(ratings).reduce((s, v) => s + Number(v), 0) /
+    Object.values(ratings).length;
+
+  const insertData = {
+    type: "volunteer_survey",
+    status: "submitted",
+    source: "web_form",
+    applicant_name: null, // anonymous
+    applicant_email: null, // anonymous
+    applicant_phone: null, // anonymous
+    submitted_at: new Date().toISOString(),
+    applicant_profile: {
+      form_key: "volunteer-satisfaction-survey-v1",
+      anonymous: true,
+      submitted_at: new Date().toISOString(),
+      payload: {
+        ratings,
+        role: body.role || "Prefer not to say",
+        best_part: body.best_part || "",
+        improvement_suggestions: body.improvement_suggestions || "",
+        average_score: avgScore.toFixed(1),
+      },
+    },
+    internal_flags: {
+      form_type: "volunteer-satisfaction-survey-v1",
+      anonymous: true,
+    },
+  };
+
+  const { data: row, error } = await supabase
+    .from("applications")
+    .insert(insertData)
+    .select("id")
+    .single();
+
+  if (error || !row?.id) {
+    console.error("[volunteer-survey] Insert failed:", error?.message);
+    return NextResponse.json(
+      { ok: false, error: "Failed to save response" },
+      { status: 500 }
+    );
+  }
+
+  // Send email notification (non-blocking — don't fail the submission)
+  sendEmailNotification(body).catch((err) =>
+    console.error("[volunteer-survey] Email error:", err)
+  );
+
+  return NextResponse.json({ ok: true, id: row.id });
+}


### PR DESCRIPTION
## Summary

CR-112: Anonymous Volunteer Satisfaction Survey with admin dashboard and email notifications.

## Deliverables

### 1. Survey form — `/volunteer-survey`
8 rating questions (1-5 scale):
- Communication clarity
- Scheduling & coordination
- Leadership support
- Tools & preparedness
- Event experience
- Comfort raising concerns
- Feeling valued
- Overall satisfaction

Plus: optional role selector, 2 free-text fields. Anonymous — no identity fields.

### 2. Submission API — `/api/forms/volunteer-survey/submit`
- Stores in existing `applications` table (type: `volunteer_survey`)
- Computes average score
- Rate limited
- Sends email to Lori@rmgreatdane.org via Resend API

### 3. Admin dashboard — `/admin/survey-dashboard`
- Summary cards (total responses, overall satisfaction, role breakdown)
- Aggregate rating bars per question
- Individual response cards with ratings + free text
- Auth-protected via existing middleware

### 4. Admin nav
Added Applications / Surveys / Intent nav links to admin header.

## Repo patterns reused
- Supabase `applications` table (same as adoption/foster/volunteer)
- Admin layout + middleware auth
- Rate limiting pattern from volunteer submit
- Form UI patterns from adoption-foster form

## Anonymity
No name, email, phone, or identity fields collected. Role is optional. IP is not stored in the submission. The `anonymous: true` flag is set in `internal_flags`.

## Email
Requires `RESEND_API_KEY` env var. Without it, submissions still save but email is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)