### PR TITLE
fix(CR-112): survey submissions now save (type constraint fix)

### DIFF
--- a/src/app/admin/survey-dashboard/page.tsx
+++ b/src/app/admin/survey-dashboard/page.tsx
@@ -66,8 +66,9 @@ export default async function SurveyDashboardPage() {
 
   const { data, error } = await supabase
     .from("applications")
-    .select("id, submitted_at, applicant_profile")
-    .eq("type", "volunteer_survey")
+    .select("id, submitted_at, applicant_profile, internal_flags")
+    .eq("type", "volunteer")
+    .contains("internal_flags", { form_type: "volunteer-satisfaction-survey-v1" })
     .order("submitted_at", { ascending: false })
     .limit(100);
 

--- a/src/app/api/forms/volunteer-survey/submit/route.ts
+++ b/src/app/api/forms/volunteer-survey/submit/route.ts
@@ -164,7 +164,7 @@ export async function POST(req: NextRequest) {
     Object.values(ratings).length;
 
   const insertData = {
-    type: "volunteer_survey",
+    type: "volunteer", // uses existing check constraint; form_type in internal_flags distinguishes survey from application
     status: "submitted",
     source: "web_form",
     applicant_name: null, // anonymous


### PR DESCRIPTION
## Fix

The Supabase `applications` table has a check constraint limiting `type` to: adopt, contact, surrender, volunteer. Using `volunteer_survey` was rejected.

Changed to `type: 'volunteer'` and distinguish surveys via `internal_flags.form_type = 'volunteer-satisfaction-survey-v1'`. Dashboard query updated accordingly.

Verified: direct insert succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)