### PR TITLE
fix: enforce Jotform redirects — adoption/foster pages not redirecting

### DIFF
--- a/src/app/(main)/adoption-application/page.tsx
+++ b/src/app/(main)/adoption-application/page.tsx
@@ -1,14 +1,11 @@
-import AdoptionFosterForm from '@/components/forms/AdoptionFosterForm'
+import { redirect } from "next/navigation";
 
-export const metadata = {
-  title: 'Adoption/Foster Application | RMGDRI',
-  description: 'Apply to adopt or foster a Great Dane from Rocky Mountain Great Dane Rescue.',
-}
-
+/**
+ * Adoption Application — redirects to legacy Jotform for launch safety.
+ * TTP-RMGDRI-JOTFORM-CUTOVER-SAFETY-001
+ *
+ * Internal Stage 1 form preserved at /apply/adopt (auth-gated).
+ */
 export default function AdoptionApplicationPage() {
-  return (
-    <main className="pb-20 bg-white">
-      <AdoptionFosterForm defaultType="adopt" title="Adoption/Foster Application" />
-    </main>
-  )
+  redirect("https://form.jotform.com/RMGDRI/adoption-foster-application");
 }

--- a/src/app/(main)/adoption-information/page.tsx
+++ b/src/app/(main)/adoption-information/page.tsx
@@ -232,7 +232,7 @@ export default function AdoptionInformationPage() {
               Meet Our Available Danes
             </Link>
             <Link
-              href="/adoption-application"
+              href="https://form.jotform.com/RMGDRI/adoption-foster-application"
               className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white px-6 py-3 rounded-lg font-semibold transition-colors"
             >
               Apply to Adopt

--- a/src/app/(main)/foster-a-great-dane/page.tsx
+++ b/src/app/(main)/foster-a-great-dane/page.tsx
@@ -164,7 +164,7 @@ export default function FosterPage() {
               Take the first step in saving a Great Dane&apos;s life. Apply to become a foster family today!
             </p>
             <Link
-              href="/foster-application"
+              href="https://form.jotform.com/RMGDRI/adoption-foster-application"
               className="inline-block bg-white text-teal-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition-colors"
             >
               Apply to Foster

--- a/src/app/(main)/foster-application/page.tsx
+++ b/src/app/(main)/foster-application/page.tsx
@@ -1,14 +1,11 @@
-import AdoptionFosterForm from '@/components/forms/AdoptionFosterForm'
+import { redirect } from "next/navigation";
 
-export const metadata = {
-  title: 'Foster Application | RMGDRI',
-  description: 'Apply to become a foster home for Great Danes with Rocky Mountain Great Dane Rescue.',
-}
-
+/**
+ * Foster Application — redirects to legacy Jotform for launch safety.
+ * TTP-RMGDRI-JOTFORM-CUTOVER-SAFETY-001
+ *
+ * Internal Stage 1 form preserved at /apply/foster (auth-gated).
+ */
 export default function FosterApplicationPage() {
-  return (
-    <main className="pb-20 bg-white">
-      <AdoptionFosterForm defaultType="foster" title="Foster Application" />
-    </main>
-  )
+  redirect("https://form.jotform.com/RMGDRI/adoption-foster-application");
 }

--- a/src/app/(main)/volunteer/page.tsx
+++ b/src/app/(main)/volunteer/page.tsx
@@ -105,7 +105,7 @@ export default function VolunteerPage() {
                   heart and home? Complete a Foster Application to get started today.
                 </p>
                 <Link
-                  href="/foster-application"
+                  href="https://form.jotform.com/RMGDRI/adoption-foster-application"
                   className="block w-full bg-teal-600 hover:bg-teal-700 text-white text-center px-6 py-3 rounded-lg font-bold transition-colors"
                 >
                   Start Now →


### PR DESCRIPTION
## CRITICAL FIX

The `/adoption-application` and `/foster-application` pages on the live site are still serving the internal `AdoptionFosterForm` instead of redirecting to Jotform.

**Root cause:** The Jotform redirect changes were made during the cutover safety work but were only in the working tree — never committed to `main`.

## What this fixes
- `/adoption-application` → redirect to Jotform ✅
- `/foster-application` → redirect to Jotform ✅
- `/adoption-information` CTA → Jotform ✅
- `/foster-a-great-dane` CTA → Jotform ✅
- `/volunteer` foster link → Jotform ✅

## What's unchanged
- Intake pause routes (already correct)
- Header/Footer links (already correct from PR #120)
- Volunteer route

🤖 Generated with [Claude Code](https://claude.com/claude-code)