### PR TITLE
feat: show interested-in CTA for foster-needed danes (CR-124)

### DIFF
--- a/src/app/(main)/available-danes/[slug]/page.tsx
+++ b/src/app/(main)/available-danes/[slug]/page.tsx
@@ -303,7 +303,7 @@ export default async function DogDetailPage({
         )}
 
         {/* CTA */}
-        {(dog.status === "available" || dog.status === "under-evaluation") && (
+        {(dog.status === "available" || dog.status === "under-evaluation" || dog.status === "foster-needed") && (
           <div className="bg-gradient-to-r from-teal-500 to-emerald-500 text-white p-8 rounded-xl shadow-lg">
             <h3 className="text-2xl font-bold mb-3">
               💚 Interested in {dog.name}?
@@ -312,7 +312,7 @@ export default async function DogDetailPage({
               Apply to foster or foster-to-adopt {dog.name} today—and help this sweet pup start their next chapter!
             </p>
             <p className="text-white/90 mb-6">
-              If you would like to adopt or foster-to-adopt {dog.name}, submit your application on our website.
+              If you would like to {dog.status === "foster-needed" ? "foster" : "adopt"} or foster-to-adopt {dog.name}, submit your application on our website.
               If you are already an approved family, reach out to us at{' '}
               <a href="mailto:placements@rmgreatdane.org" className="underline font-semibold">
                 placements@rmgreatdane.org


### PR DESCRIPTION
## Summary
- Extends the green "💚 Interested in {name}?" CTA on `/available-danes/[slug]` to render for dogs with `status="foster-needed"`, in addition to `available` and `under-evaluation`.
- For foster-needed dogs, the second paragraph now reads "If you would like to foster or foster-to-adopt {name}…" instead of "adopt or foster-to-adopt"; existing copy for `available`/`under-evaluation` is unchanged.
- Both Jotform CTA buttons (Start an Application / Foster Application) and the placements@rmgreatdane.org contact remain identical.

## Files changed
- `src/app/(main)/available-danes/[slug]/page.tsx` — two-line edit (conditional + verb)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [ ] Preview deploy: visit `/available-danes/<foster-needed-slug>` (e.g. Bruce) and confirm green CTA renders with foster-worded copy
- [ ] Confirm `/available-danes/<available-slug>` copy is unchanged ("If you would like to adopt or foster-to-adopt…")
- [ ] Confirm pages with other statuses (medical-hold, behavior-hold, pending, etc.) still hide the CTA

Closes #124