### PR TITLE
feat: extend CTA to in-rescue statuses, unify verb (CR-125 reland)

### DIFF
--- a/src/app/(main)/available-danes/[slug]/page.tsx
+++ b/src/app/(main)/available-danes/[slug]/page.tsx
@@ -89,6 +89,8 @@ export default async function DogDetailPage({
     'rainbow-bridge': 'Rainbow Bridge',
   };
 
+  const ctaVerb = dog.status === "foster-needed" ? "foster" : "adopt";
+
   return (
     <main className="min-h-screen bg-white">
       <div className="max-w-5xl mx-auto px-4 py-12">
@@ -303,16 +305,21 @@ export default async function DogDetailPage({
         )}
 
         {/* CTA */}
-        {(dog.status === "available" || dog.status === "under-evaluation" || dog.status === "foster-needed") && (
+        {(dog.status === "available" ||
+          dog.status === "under-evaluation" ||
+          dog.status === "foster-needed" ||
+          dog.status === "medical-hold" ||
+          dog.status === "behavior-hold" ||
+          dog.status === "waiting-transport") && (
           <div className="bg-gradient-to-r from-teal-500 to-emerald-500 text-white p-8 rounded-xl shadow-lg">
             <h3 className="text-2xl font-bold mb-3">
               💚 Interested in {dog.name}?
             </h3>
             <p className="text-white/90 mb-6 text-lg">
-              Apply to foster or foster-to-adopt {dog.name} today—and help this sweet pup start their next chapter!
+              Apply to {ctaVerb} or foster-to-adopt {dog.name} today—and help this sweet pup start their next chapter!
             </p>
             <p className="text-white/90 mb-6">
-              If you would like to {dog.status === "foster-needed" ? "foster" : "adopt"} or foster-to-adopt {dog.name}, submit your application on our website.
+              If you would like to {ctaVerb} or foster-to-adopt {dog.name}, submit your application on our website.
               If you are already an approved family, reach out to us at{' '}
               <a href="mailto:placements@rmgreatdane.org" className="underline font-semibold">
                 placements@rmgreatdane.org


### PR DESCRIPTION
## Why this PR exists
PR #127 was squash-merged into the **stacked base branch** `cr-124-foster-needed-cta` rather than into `main`. GitHub did not auto-retarget the base after PR #126 (CR-124) was squash-merged, so the CR-125 squash commit (`de4c343`) landed on the stale stacked branch and never reached production.

This PR cherry-picks `de4c343` onto a fresh branch off `main` so the change actually ships.

## Summary
- Extends the green "💚 Interested in {name}?" CTA on `/available-danes/[slug]` so it renders for every dog in rescue with a Dog ID — adds `medical-hold`, `behavior-hold`, and `waiting-transport` on top of the existing `available`, `under-evaluation`, and `foster-needed` statuses.
- Single `ctaVerb` const drives both paragraphs:
  - `foster-needed` → "foster or foster-to-adopt" (preserves CR-124).
  - All other in-rescue statuses → "adopt or foster-to-adopt".
- First paragraph for in-rescue dogs flips from "Apply to foster or foster-to-adopt…" to "Apply to adopt or foster-to-adopt…", which is the actual ask of CR-125.

## Files changed
- `src/app/(main)/available-danes/[slug]/page.tsx` (+10 / −3)

## Behavioral matrix
| Status | CTA shown? | Verb |
|---|---|---|
| available, under-evaluation, medical-hold, behavior-hold, waiting-transport | ✅ | adopt |
| foster-needed | ✅ | foster |
| pending, permanent-foster, adopted, rainbow-bridge | ❌ | — |

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Cherry-pick applied without conflict; diff vs `main` is byte-identical to the original PR #127 diff
- [ ] Preview deploy: visit Bryce (the URL named in CR-125) and confirm both paragraphs read "adopt or foster-to-adopt"
- [ ] Visit a `medical-hold` / `behavior-hold` / `waiting-transport` dog and confirm CTA renders with "adopt"
- [ ] Visit a `foster-needed` dog (e.g. Bruce) and confirm CTA still renders with "foster" (CR-124 behavior preserved)

## Cleanup
After this merges, the stale `cr-124-foster-needed-cta` branch should be deleted (it was never re-merged after #126's squash).

Closes #125