### PR TITLE
feat: rename /utah-events → /events, sort by date, bold event header (CR-129)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,15 @@ const nextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/utah-events',
+        destination: '/events',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/src/app/(main)/events/page.tsx
+++ b/src/app/(main)/events/page.tsx
@@ -63,7 +63,11 @@ export default async function EventsPage() {
   const events = await getEvents()
 
   const now = new Date()
-  const upcomingEvents = events.filter((e: any) => new Date(e.startDate) >= now)
+  const byStartDateAsc = (a: any, b: any) =>
+    new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+  const upcomingEvents = events
+    .filter((e: any) => new Date(e.startDate) >= now)
+    .sort(byStartDateAsc)
   const pastEvents = events.filter((e: any) => new Date(e.startDate) < now)
 
   return (
@@ -122,7 +126,7 @@ export default async function EventsPage() {
 
                     {/* Event Details */}
                     <div className="flex-grow min-w-0">
-                      <div className="flex items-center gap-2 mb-2">
+                      <div className="flex items-center gap-2 mb-2 font-bold">
                         <span className="text-xl">{eventTypeEmoji[event.eventType] || '📅'}</span>
                         <span className="text-sm text-gray-500 capitalize">{event.eventType}</span>
                         <span className="text-gray-300">•</span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Rehome a Dane</Link></li>
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Shelter Transfers</Link></li>
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Surrender a Dane</Link></li>
-              <li><Link href="/utah-events" className="hover:text-white transition-colors">Utah Events</Link></li>
+              <li><Link href="/events" className="hover:text-white transition-colors">Utah Events</Link></li>
             </ul>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -108,7 +108,7 @@ export default function Header() {
               </div>
 
               {/* Events - no dropdown */}
-              <Link href="/utah-events" className="px-4 py-2 text-gray-700 hover:text-teal-600 hover:bg-teal-50 rounded-lg font-medium transition-colors">
+              <Link href="/events" className="px-4 py-2 text-gray-700 hover:text-teal-600 hover:bg-teal-50 rounded-lg font-medium transition-colors">
                 Events
               </Link>
 


### PR DESCRIPTION
## Summary
Three fixes to the events page per CR-129:

1. **URL rename**: `/utah-events` → `/events`. The page was moved (`git mv`) so a single canonical route now lives at `/events`. A permanent (308) redirect from `/utah-events` → `/events` is added in `next.config.mjs` so existing links and bookmarks keep working.
2. **Date order (defensive)**: upcoming events are now explicitly sorted asc by `startDate` in JS after the upcoming/past split. The Sanity GROQ already orders `asc`, but the operator reported events not appearing soonest-first, so this guarantees deterministic order regardless of source ordering.
3. **Bold event header**: the row that renders "💰 fundraiser • Utah" now has `font-bold` on its container, so the emoji, event type, separator, and region all render bold.

## Files changed
- `src/app/(main)/utah-events/page.tsx` → `src/app/(main)/events/page.tsx` (rename, 97% similarity, +8 / −2 inside the file)
- `next.config.mjs` (+9): add `redirects()` returning `/utah-events → /events` permanent
- `src/components/Header.tsx` (+1 / −1): nav `<Link href="/events">`
- `src/components/Footer.tsx` (+1 / −1): footer `<Link href="/events">`

## Scope notes
- The footer label still reads **"Utah Events"** even though the URL is now `/events`. The CR did not request a label change, so I left it. Happy to ship a one-line follow-up if you want it renamed to "Events" for consistency.
- Past events ordering and slicing was not touched (CR did not mention it).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds; build manifest now lists `/events` (no `/utah-events`); Tailwind verifier PASS
- [ ] Preview deploy: visit `/events` and confirm page renders, upcoming events appear soonest-first, event header line is bold
- [ ] Visit `/utah-events` on the preview and confirm 308 redirect to `/events`
- [ ] Click "Events" in the top nav and confirm it navigates to `/events`
- [ ] Click "Utah Events" in the footer and confirm it navigates to `/events`

Closes #129