### PR TITLE
fix(seo): redirect available-great-danes to available-danes (#132)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -63,6 +63,13 @@ const nextConfig = {
       { source: '/oakley', destination: '/available-danes/oakley', permanent: true },
       { source: '/oakley/', destination: '/available-danes/oakley', permanent: true },
 
+      // ── Legacy WP /available-great-danes index alias (CR-132 2026-05-06) ──
+      // The old WordPress site exposed the available-Danes index at
+      // /available-great-danes/. The new Next.js site uses /available-danes/.
+      // Previously caught by gone-patterns.ts (returned 410); reclassified here.
+      { source: '/available-great-danes', destination: '/available-danes', permanent: true },
+      { source: '/available-great-danes/', destination: '/available-danes', permanent: true },
+
       // ── Success-story + section mappings (Phase B 2026-05-05) ──
       { source: '/category/successes/2023-successes/page/2', destination: '/adoption-successes/2023', permanent: true },
       { source: '/category/successes/2023-successes/page/3', destination: '/adoption-successes/2023', permanent: true },

--- a/src/data/gone-patterns.ts
+++ b/src/data/gone-patterns.ts
@@ -708,7 +708,8 @@ export const GONE_LITERALS = new Set<string>([
   "/author/lwersinger/page/2",
   "/ava",
   "/ava-has-a-home",
-  "/available-great-danes",
+  // /available-great-danes redirected to /available-danes (CR-132).
+  // /available-great-danes-2 and /available-great-danes/feed remain 410.
   "/available-great-danes-2",
   "/available-great-danes/feed",
   "/axel",


### PR DESCRIPTION
## Summary
- Resolves #132. Legacy WordPress URL `/available-great-danes/` was misclassified as 410 Gone in PR #131. Reclassified as a 308 permanent redirect to the new Next.js path `/available-danes`.
- `next.config.mjs`: added redirect rules for both `/available-great-danes` and `/available-great-danes/`, following the existing `/kevin`/`/kevin/` Confirmed-7 pattern.
- `src/data/gone-patterns.ts`: removed the `/available-great-danes` literal. Per CR scope, the siblings `/available-great-danes-2` and `/available-great-danes/feed` remain 410.

## Scope discipline
- Branched off current `origin/main` (c93505c), not from any feature/WIP branch.
- No other redirects modified. No middleware logic changes.
- Diff: 9 lines across 2 files.

## Local verification (worktree, port 3132)
| # | Test | Result |
|---|---|---|
| T1 | `/available-great-danes` | 308 → `/available-danes` ✅ |
| T2 | `/available-great-danes/` | 308 → `/available-great-danes` → 308 → `/available-danes` (PASS-but-chain, same `trailingSlash:false` framework behavior accepted in PR #131) ✅ |
| T3 | `/available-danes` | 200 ✅ |
| T4 | `/jumbo` (existing CR-129 redirect) | 308 → `/available-danes/jumbo-jet` ✅ |
| T5 | `/2017-adoptions` (existing 410) | 410 ✅ |
| T6 | `/wp-login.php` (existing 410) | 410 ✅ |
| T7 | `/available-great-danes-2` (sibling, untouched) | 410 ✅ |
| T8 | `/available-great-danes/feed` (sibling, untouched) | 410 ✅ |

## Build / typecheck
- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `npx next build` → exit 0, compiled 14.6s, middleware bundle 44.7 kB

## Test plan
- [ ] Wait for Vercel preview deployment Ready
- [ ] Re-run T1–T8 against the preview alias
- [ ] Confirm no regressions on representative existing redirects and 410s
- [ ] Merge to `main`, verify against rmgdri-site.vercel.app