### PR TITLE
fix(content): footer Get Involved menu — rename Utah Events to Events (#133)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Rehome a Dane</Link></li>
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Shelter Transfers</Link></li>
               <li><Link href="/intake-pause" className="hover:text-white transition-colors">Surrender a Dane</Link></li>
-              <li><Link href="/events" className="hover:text-white transition-colors">Utah Events</Link></li>
+              <li><Link href="/events" className="hover:text-white transition-colors">Events</Link></li>
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary
Resolves #133. Footer "Get Involved" column previously listed "Utah Events" while the rest of the site (page header, nav menu) had already been updated to "Events" by PR #130 (CR-129). This catches the missed footer label.

- `src/components/Footer.tsx`: line 32 visible text changes from `Utah Events` to `Events`. The `href="/events"` is unchanged.

## Diff
1 file changed, 1 insertion, 1 deletion.

## Local verification (worktree, port 3133)
| # | Test | Result |
|---|---|---|
| T1 | Home footer "Get Involved" renders `Events` | ✅ |
| T2 | `Utah Events` count on home | **0** ✅ |
| T3 | `href="/events">Events</a>` (nav + footer) | 2 instances ✅ |
| T4 | `Utah Events` count on `/events` page | **0** ✅ |
| T5 | `Utah Events` count on `/about-rmgdri` | **0** ✅ |
| T6 | `/available-great-danes` (CR-132 in base) | 308 → `/available-danes` ✅ |
| T7 | `/wp-login.php` (existing 410) | 410 ✅ |

Final grep: zero `Utah Events` remaining anywhere in `src/`.

## Build / typecheck
- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `npx next build` → success, middleware bundle 44.9 kB

## Test plan
- [ ] Wait for Vercel preview deployment Ready
- [ ] Confirm footer "Get Involved" column reads `Events` on the preview alias
- [ ] Confirm `/events` link still resolves correctly from the footer
- [ ] Merge to `main`, verify on rmgdri-site.vercel.app