### PR TITLE
fix(forms): remove test-only Resend survey email sender

### DIFF
--- a/src/app/api/forms/volunteer-survey/submit/route.ts
+++ b/src/app/api/forms/volunteer-survey/submit/route.ts
@@ -2,9 +2,10 @@
  * POST /api/forms/volunteer-survey/submit
  *
  * Anonymous Volunteer Satisfaction Survey submission handler.
- * - Stores response in Supabase applications table (type: "volunteer_survey")
- * - Sends email notification to Lori@rmgreatdane.org
+ * - Stores response in Supabase applications table (type: "volunteer")
  * - No identity fields collected — anonymous by design
+ *
+ * Responses are reviewed via the admin dashboard.
  */
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
@@ -19,77 +20,6 @@ function isRateLimited(ip: string): boolean {
   log.push(now);
   hits.set(ip, log);
   return log.length > 5;
-}
-
-/* ── Email helper ── */
-async function sendEmailNotification(data: Record<string, unknown>) {
-  const resendKey = process.env.RESEND_API_KEY;
-  if (!resendKey) {
-    console.warn("[volunteer-survey] RESEND_API_KEY not set — skipping email");
-    return;
-  }
-
-  const ratings = (data.ratings ?? {}) as Record<string, string>;
-  const ratingLabels: Record<string, string> = {
-    communication: "Communication clarity",
-    scheduling: "Scheduling & coordination",
-    leadership_support: "Leadership support",
-    tools_preparedness: "Tools & preparedness",
-    event_experience: "Event experience",
-    raise_concerns: "Comfort raising concerns",
-    valued: "Feeling valued",
-    overall: "Overall satisfaction",
-  };
-
-  const ratingLines = Object.entries(ratingLabels)
-    .map(([key, label]) => `${label}: ${ratings[key] || "—"}/5`)
-    .join("\n");
-
-  const avgScore =
-    Object.values(ratings).length > 0
-      ? (
-          Object.values(ratings).reduce((s, v) => s + Number(v || 0), 0) /
-          Object.values(ratings).length
-        ).toFixed(1)
-      : "N/A";
-
-  const body = `New Volunteer Satisfaction Survey Response
-
-Role: ${data.role || "Not specified"}
-Average Score: ${avgScore}/5
-Submitted: ${new Date().toLocaleString("en-US", { timeZone: "America/Denver" })}
-
---- Ratings ---
-${ratingLines}
-
---- What they enjoy most ---
-${data.best_part || "(no response)"}
-
---- Improvement suggestions ---
-${data.improvement_suggestions || "(no response)"}
-`;
-
-  try {
-    const res = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${resendKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        from: process.env.RESEND_FROM_EMAIL || "RMGDRI Surveys <surveys@rmgreatdane.org>",
-        to: ["Lori@rmgreatdane.org"],
-        subject: `Volunteer Survey Response — ${avgScore}/5 avg (${data.role || "Anonymous"})`,
-        text: body,
-      }),
-    });
-    if (!res.ok) {
-      const err = await res.text();
-      console.error("[volunteer-survey] Email send failed:", res.status, err);
-    }
-  } catch (err) {
-    console.error("[volunteer-survey] Email send error:", err);
-  }
 }
 
 /* ── Handler ── */
@@ -202,11 +132,6 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
-
-  // Send email notification (non-blocking — don't fail the submission)
-  sendEmailNotification(body).catch((err) =>
-    console.error("[volunteer-survey] Email error:", err)
-  );
 
   return NextResponse.json({ ok: true, id: row.id });
 }


### PR DESCRIPTION
Removes the test-only Resend email-notification path from the volunteer-survey submit route. **Unblocks CR-A SPF cleanup on the Resend axis** (Issue #139).

## Background

Per the CR-A Gate B dependency-evidence inspection (Issue #139, https://github.com/rayrich01/RMGDRI-Website/issues/139#issuecomment-4393081903 and follow-up), the Resend email-notification path in `src/app/api/forms/volunteer-survey/submit/route.ts` is classified **TEST_ONLY / effectively dead in production**:

- `RESEND_API_KEY` is not present in the local env and not in the documented Vercel env-var roster.
- The helper short-circuits when the key is missing (`if (!resendKey) { console.warn(...); return; }`), so the path has never operationally fired.
- The hardcoded fallback sender `surveys@rmgreatdane.org` is not a real Google Workspace mailbox (per Lori).
- `/volunteer-survey` is reachable but unlinked from public navigation.

Lori does not need to be notified by email; survey responses are reviewable via the admin dashboard.

## What this PR removes

- `sendEmailNotification()` function and its call site
- All source references to:
  - `RESEND_API_KEY`
  - `RESEND_FROM_EMAIL`
  - `surveys@rmgreatdane.org`
  - `api.resend.com`
  - `Resend` (case-insensitive)

## What this PR preserves

- `/volunteer-survey` page (UI unchanged)
- `/api/forms/volunteer-survey/submit` route (POST handler still active)
- Supabase database write behavior (insertion to `applications` table)
- All cutover protections (CR-131/132/133/137/138/A/B/C unchanged)
- `.env.local.example` (gitignored / not tracked — separate tiny CR if you want it tracked later)

## Diff

1 file changed, 3 insertions, 78 deletions in `src/app/api/forms/volunteer-survey/submit/route.ts`.

## CR-A impact

| CR-A blocker | Status after this PR |
|---|---|
| **Resend in SPF** | **RESOLVED** — Resend no longer participates as a sender |
| **DMARC reporting mailbox** | unchanged — still pending Lori-side `dmarc-reports@rmgreatdane.org` decision + Ray authorization |
| **DMARC observation window** | unchanged — ≥2 weeks of `p=none` aggregate reports still required after publish |
| **Newtek/IPM mail-off confirmation** | unchanged — coupled to CR-B cPanel/FTP decommission |
| **Final SPF target** (after all blockers clear) | now simply `v=spf1 include:_spf.google.com ~all` — no Resend include needed |

No Resend SPF/DKIM support is required after this change.

## Verification

**grep proof — 0 hits in `src/`:**
| Term | Hits |
|---|---|
| `RESEND_API_KEY` | 0 |
| `RESEND_FROM_EMAIL` | 0 |
| `surveys@rmgreatdane.org` | 0 |
| `api.resend.com` | 0 |
| `[Rr]esend` (case-insensitive) | 0 |

**Build / typecheck:**
- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `npx next build` → success

**Local server (port 3146):**
| # | Test | Result |
|---|---|---|
| T1 | `/volunteer-survey` loads | HTTP 200, `text/html` ✅ |
| T2 | API endpoint exists (HEAD) | 405 (POST-only — expected) ✅ |
| T3 | POST with invalid body | 400 (handler reachable, validation working) ✅ |
| T4 | `/available-great-danes` (CR-132) | 308 → `/available-danes` ✅ |
| T4 | `/wp-login.php` (410) | 410 ✅ |
| T4 | `/wp-content/uploads/2024/06/Ada-Success.png` (CR-137) | 200 ✅ |
| T4 | `/events` page | 200 ✅ |
| T5 | Footer Events label (CR-133) | `Utah Events` count = 0; `href="/events">Events</a>` rendered ✅ |

## Limitation

**No live Supabase write test performed** to avoid polluting production data. The handler-reachability proof (T3 — 400 on invalid POST) confirms the route executes through the validation layer; the Supabase insert step is exercised by build-time type checking but not by a runtime end-to-end write.

## Compliance

- ✅ No DNS / Cloudflare / Vercel / SPF / DMARC / DKIM / MX changes
- ✅ No middleware modifications
- ✅ No CR-A / CR-B / CR-C Gate B execution
- ✅ No `/apply/adopt` modifications
- ✅ No primary worktree WIP or stash modifications
- ✅ Stash count unchanged (19)
- ✅ No Misha CRs executed

## Test plan

- [ ] Reviewer confirms diff is route-file-only
- [ ] Wait for CI checks + Vercel preview Ready
- [ ] Optional: submit a real volunteer-survey response on the preview alias and confirm it appears in Supabase admin dashboard
- [ ] Confirm no regression to CR-A/B/C dispositions
- [ ] Merge to `main` (closes the Resend axis of CR-A)