### PR TITLE
fix(cr-system): stop watchdog spam on closed auto-execute CRs (#146)

### DIFF
--- a/.github/workflows/cr-manual-closeout.yml
+++ b/.github/workflows/cr-manual-closeout.yml
@@ -102,7 +102,40 @@ jobs:
             if (eventAction !== 'closed') return;
 
             if (!isManualRoute) {
-              core.info(`CR-${issueNumber}: closed but not a manual-route CR — skipping`);
+              // ══════════════════════════════════════════════════════════
+              // AUTO-ROUTE CLOSEOUT
+              // Reconcile Supabase row when an auto-execute CR is closed
+              // outside the executor's review path. Otherwise the row stays
+              // in a non-terminal status and the watchdog keeps posting
+              // SLA-exceeded comments to the closed issue.
+              // Only flips non-terminal rows; respects 'done'/'failed'.
+              // ══════════════════════════════════════════════════════════
+              if (labelNames.includes('cr-auto-execute') && sbHeaders) {
+                core.info(`CR-${issueNumber}: auto-execute CR closed — reconciling Supabase`);
+                try {
+                  const url = `${sbUrl}/rest/v1/cr_tasks?cr_number=eq.${issueNumber}&tenant=eq.rmgdri&status=in.(pending,executing,review)`;
+                  const res = await fetch(url, {
+                    method: 'PATCH',
+                    headers: sbHeaders,
+                    body: JSON.stringify({
+                      status: 'cancelled',
+                      completed_at: new Date().toISOString(),
+                      result: {
+                        closeout_method: 'auto-route-manual-close',
+                        closed_by: context.payload.sender?.login
+                      }
+                    })
+                  });
+                  if (!res.ok) {
+                    const text = await res.text();
+                    core.warning(`CR-${issueNumber}: Supabase PATCH failed (${res.status}): ${text}`);
+                  }
+                } catch (e) {
+                  core.warning(`CR-${issueNumber}: Supabase PATCH error: ${e.message}`);
+                }
+              } else {
+                core.info(`CR-${issueNumber}: closed but not a manual-route CR — skipping`);
+              }
               return;
             }
 

--- a/.github/workflows/cr-watchdog.yml
+++ b/.github/workflows/cr-watchdog.yml
@@ -313,6 +313,45 @@ jobs:
                 for (const task of pendingTasks) {
                   const pendingMinutes = (now - new Date(task.queued_at)) / (1000 * 60);
                   if (pendingMinutes > 30) {
+                    // Cross-check GitHub state — the cr_tasks row may be stale
+                    // if the issue was closed without executor pickup.
+                    let issueState = 'open';
+                    try {
+                      const { data: issue } = await github.rest.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: task.cr_number
+                      });
+                      issueState = issue.state;
+                    } catch (e) {
+                      core.warning(`CR-${task.cr_number}: issue lookup failed — ${e.message}`);
+                      continue;
+                    }
+
+                    if (issueState === 'closed') {
+                      core.info(`CR-${task.cr_number}: issue closed — reconciling cr_tasks row to cancelled`);
+                      try {
+                        const reconcileRes = await fetch(
+                          `${sbUrl}/rest/v1/cr_tasks?cr_number=eq.${task.cr_number}&tenant=eq.rmgdri&status=eq.pending`,
+                          {
+                            method: 'PATCH',
+                            headers: { ...headers, Prefer: 'return=minimal' },
+                            body: JSON.stringify({
+                              status: 'cancelled',
+                              result: { closeout_method: 'watchdog-reconciled', closeout_at: new Date().toISOString() }
+                            })
+                          }
+                        );
+                        if (!reconcileRes.ok) {
+                          const text = await reconcileRes.text();
+                          core.warning(`CR-${task.cr_number}: reconcile PATCH failed (${reconcileRes.status}): ${text}`);
+                        }
+                      } catch (e) {
+                        core.warning(`CR-${task.cr_number}: reconcile PATCH error: ${e.message}`);
+                      }
+                      continue;
+                    }
+
                     const hasRecent = await hasRecentWatchdogComment(task.cr_number, 1);
                     if (!hasRecent) {
                       await github.rest.issues.createComment({

--- a/_ttp/CR-146/CR-146-001-IMPLEMENTATION-REPORT.md
+++ b/_ttp/CR-146/CR-146-001-IMPLEMENTATION-REPORT.md
@@ -1,0 +1,88 @@
+# CR-146-001: Implementation Report
+
+**CR:** [#146](https://github.com/rayrich01/RMGDRI-Website/issues/146) — Service Watchdog spams closed auto-execute CRs
+**PR:** [#147](https://github.com/rayrich01/RMGDRI-Website/pull/147)
+**Branch:** `fix/cr-146-watchdog-closed-issues` (off `origin/main` at `9e371e0`)
+**Commit:** `47b2e90`
+**Authorized by:** Ray Richardson, 2026-05-09 (in-session, "Execute CR-146. I authorize this work")
+**Classification:** WORKFLOW_GOVERNANCE_GAP / REMEDIATION
+**State:** READY WITH RESTRICTIONS (pending merge + 24h observation)
+
+---
+
+## Diagnosis
+
+Closed auto-execute CRs (#133 closed 2026-05-06 18:16Z, #136 closed 2026-05-06 19:21Z) continued receiving "⏳ Service Watchdog — pending beyond SLA" comments every 6 hours, latest reporting 4382 / 4340 minutes pending. Lori reported the noise via email forward 2026-05-09.
+
+Two compounding gaps:
+
+1. **`cr-watchdog.yml` CHECK 4 (lines 302–337)** queried Supabase `cr_tasks` directly for `status=eq.pending&auto_execute=eq.true` and posted the SLA comment to whatever GitHub issue number it returned — without checking whether that issue was open or closed. The four other checks in the same workflow filter via `listForRepo({ state: 'open' })`, so this was the only check that leaked.
+
+2. **`cr-manual-closeout.yml`** had an `issues.closed` handler that PATCHed the Supabase row to a terminal status — but it explicitly excluded auto-route CRs (lines 27–29, 104–107). When an auto-execute CR was closed manually before executor pickup, the `cr_tasks` row was never reconciled. It stayed `status='pending'` forever, and CHECK 4 kept finding it.
+
+Both #133 and #136 confirmed: CLOSED on GitHub but still labeled `cr-queued` + `cr-auto-execute`, and (inferred from watchdog behavior) corresponding `cr_tasks` rows still `status='pending'`.
+
+---
+
+## Files changed
+
+```
+.github/workflows/cr-watchdog.yml        | 39 +++++++++++++++++++++++++++++++
+.github/workflows/cr-manual-closeout.yml | 35 +++++++++++++++++++++++++++-
+2 files changed, 73 insertions(+), 1 deletion(-)
+```
+
+### Change 1 — `cr-watchdog.yml` CHECK 4
+
+Inside the existing `for (const task of pendingTasks)` loop, added a GitHub-state cross-check. If `github.rest.issues.get` returns `state === 'closed'`, PATCH the orphaned `cr_tasks` row to `status='cancelled'` and `continue` to the next task. Existing comment-posting path is unchanged for genuinely open issues.
+
+Errors on either the `issues.get` lookup or the reconcile PATCH are logged via `core.warning` and the loop continues — matches the surrounding workflow's error-handling style.
+
+### Change 2 — `cr-manual-closeout.yml` AUTO-ROUTE CLOSEOUT
+
+Replaced the bare early-return for non-manual-route CRs with a branch that:
+
+- If the closed issue carries `cr-auto-execute` AND Supabase headers are configured, PATCH `cr_tasks` to `status='cancelled'` with `completed_at` set and `result.closeout_method='auto-route-manual-close'`.
+- Status filter `in.(pending,executing,review)` ensures terminal states (`done` / `failed`) the executor may have set are not overwritten.
+- Otherwise, log the existing skip message and return.
+
+---
+
+## Pre-flight & validation evidence
+
+- **Pre-flight (1st run):** FAILED — was on `hotfix/legacy-upload-thumbnails` with significant unrelated WIP in working tree. Stopped per RMGDRI CLAUDE.md rule 4 and reported to Ray.
+- **Pre-flight (2nd run):** PASSED — Ray moved WIP to `wip/applications-dashboard` (Option 3). Branch created off `origin/main` with clean tree.
+- **YAML syntax:** PASS — `python3 -c "import yaml; yaml.safe_load(...)"` clean on both files.
+- **TypeScript:** N/A — change is YAML/CI workflows, no TS surface.
+- **Smoke test (live):** Deferred to post-merge. Requires `gh workflow run cr-watchdog.yml` against main and 24h observation per CR-Governance-Pattern-001 GO-LIVE step.
+- **Diff verified:** `git diff --stat` shows only the two intended files; no collateral changes.
+
+---
+
+## Outstanding go-live actions
+
+1. PR #147 merged to `main`.
+2. **Pre-deployment data backfill (one-time, manual, requires Supabase service-role key):**
+   ```bash
+   curl -X PATCH "$SUPABASE_URL/rest/v1/cr_tasks?cr_number=in.(133,136)&tenant=eq.rmgdri&status=eq.pending" \
+     -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+     -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"status":"cancelled","result":{"closeout_method":"manual-backfill","cr":"CR-146"}}'
+   ```
+   Without this, the new watchdog code will reconcile the rows on its next 6h tick anyway, but the manual backfill stops the symptom immediately.
+3. **Stale label cleanup on closed issues:**
+   ```bash
+   gh issue edit 133 --repo rayrich01/RMGDRI-Website --remove-label cr-queued --remove-label cr-auto-execute
+   gh issue edit 136 --repo rayrich01/RMGDRI-Website --remove-label cr-queued --remove-label cr-auto-execute
+   ```
+4. **24h observation window** — zero spurious watchdog comments on closed CRs. State transitions to LIVE on pass.
+
+---
+
+## State
+
+**REMEDIATION:** complete (PR open).
+**VALIDATION:** pending (post-merge workflow_dispatch + 24h observation).
+**GO-LIVE:** pending VALIDATION pass.
+**CLOSURE:** pending GO-LIVE.


### PR DESCRIPTION
Closes #146.

## Summary

- **`cr-watchdog.yml` CHECK 4** now cross-checks GitHub issue state before posting the "pending beyond SLA" comment. If the issue is closed, it PATCHes the orphaned `cr_tasks` row to `status='cancelled'` and skips the comment.
- **`cr-manual-closeout.yml`** previously skipped non-manual-route CRs entirely. It now reconciles the Supabase row to `status='cancelled'` when an auto-execute CR is closed, with a status filter (`in.(pending,executing,review)`) so it never overwrites terminal states (`done` / `failed`) the executor may have set.

## Why

Issues #133 and #136 (both CLOSED 2026-05-06, both still labeled `cr-queued` + `cr-auto-execute`) were receiving Service Watchdog comments every 6h, latest at 4382 / 4340 minutes pending. Root cause was a source-of-truth mismatch: the watchdog queried Supabase `cr_tasks` for pending auto-execute rows and posted to the referenced issue without checking whether the issue was still open. No upstream handler existed to reconcile the row when an auto-execute issue was closed manually before executor pickup.

Classification: **WORKFLOW_GOVERNANCE_GAP / REMEDIATION** (per CR-Governance-Pattern-001).

## Test plan

### Pre-merge data backfill (one-time, not in this PR)

The two currently-orphaned rows for #133 and #136 must be PATCHed manually before this fix takes effect (the new watchdog code will reconcile them on the next 6h tick anyway, but the manual backfill stops the bleeding immediately):

```bash
curl -X PATCH "$SUPABASE_URL/rest/v1/cr_tasks?cr_number=in.(133,136)&tenant=eq.rmgdri&status=eq.pending" \
  -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
  -H "Content-Type: application/json" \
  -d '{"status":"cancelled","result":{"closeout_method":"manual-backfill","cr":"#146"}}'

gh issue edit 133 --repo rayrich01/RMGDRI-Website --remove-label cr-queued --remove-label cr-auto-execute
gh issue edit 136 --repo rayrich01/RMGDRI-Website --remove-label cr-queued --remove-label cr-auto-execute
```

### Validation cases

**Positive**
- [ ] After merge, run `gh workflow run cr-watchdog.yml --repo rayrich01/RMGDRI-Website` — no comment posted on #133 / #136. Log shows `issue closed — reconciling cr_tasks row to cancelled` if backfill was skipped.
- [ ] Open a test issue with `cr-auto-execute`, insert a matching `cr_tasks` row with `status='pending'`, close the issue. Confirm row flips to `status='cancelled'` with `completed_at` set and `result.closeout_method='auto-route-manual-close'`.

**Negative (no-regression)**
- [ ] Open auto-execute CR, leave open; watchdog still posts SLA comment after 30min on the open issue.
- [ ] Close a CR that is already `status='done'` in Supabase (executor has finished); confirm closeout handler's `status=in.(pending,executing,review)` filter leaves the `done` row untouched.

**Regression**
- [ ] Manual-route closeout (`cr-manual-handoff` flow) still produces governed-closeout acknowledgment with evidence excerpt.
- [ ] Other four watchdog checks (manual-path, validation-failed, escalated, in-progress critical) still fire on genuinely open issues.

**Boundary**
- [ ] `github.rest.issues.get` 404 on a deleted issue — caught, `core.warning` logged, loop continues without crashing.
- [ ] Supabase PATCH non-2xx — caught, `core.warning` logged with status + body, loop continues.

### Go-live criteria

- READY WITH RESTRICTIONS until merged + 24h observation with zero spurious watchdog comments on closed CRs.
- LIVE after the 24h observation passes clean.

## Out of scope

- Refactor of CHECK 4 to use `listForRepo({ state: 'open' })` (would require label-based pendingMinutes derivation; needs schema work).
- Other four watchdog checks (already filter on `state: 'open'`).
- Executor lifecycle / intake flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)