### PR TITLE
fix(cr-system): use 'done' status for reconciled rows (#146 followup)

### DIFF
--- a/.github/workflows/cr-manual-closeout.yml
+++ b/.github/workflows/cr-manual-closeout.yml
@@ -118,7 +118,7 @@ jobs:
                     method: 'PATCH',
                     headers: sbHeaders,
                     body: JSON.stringify({
-                      status: 'cancelled',
+                      status: 'done',
                       completed_at: new Date().toISOString(),
                       result: {
                         closeout_method: 'auto-route-manual-close',

--- a/.github/workflows/cr-watchdog.yml
+++ b/.github/workflows/cr-watchdog.yml
@@ -337,7 +337,8 @@ jobs:
                             method: 'PATCH',
                             headers: { ...headers, Prefer: 'return=minimal' },
                             body: JSON.stringify({
-                              status: 'cancelled',
+                              status: 'done',
+                              completed_at: new Date().toISOString(),
                               result: { closeout_method: 'watchdog-reconciled', closeout_at: new Date().toISOString() }
                             })
                           }


### PR DESCRIPTION
Followup to #147 (CR-146). Issue: #146.

## Summary

CR-146's original fix used `status: 'cancelled'` when patching orphaned `cr_tasks` rows. That value is not in the schema's CHECK constraint (`pending, queued, executing, review, done, blocked, escalated, failed`) — every PATCH was rejected by Postgres. The watchdog's comment-suppression still worked because the unconditional `continue` ran whether or not the PATCH succeeded, but the orphaned rows were never actually reconciled.

This PR switches both PATCH bodies to `status: 'done'`, matching the existing manual-route closeout pattern. The `result.closeout_method` field continues to distinguish the closure source.

## Validation evidence (post-merge of #147)

`gh workflow run cr-watchdog.yml` at 2026-05-09 22:45Z produced:

```
✓ check-stale-crs in 6s
! CR-133: reconcile PATCH failed (400): {"code":"23514", ... "violates check constraint cr_tasks_status_check"}
! CR-136: reconcile PATCH failed (400): {"code":"23514", ... "violates check constraint cr_tasks_status_check"}
```

Issue comment count after the run: **0 new comments on #133, 0 new on #136** — primary symptom fixed even with the broken PATCH.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run cr-watchdog.yml --repo rayrich01/RMGDRI-Website --ref main`
- [ ] Run log shows zero `reconcile PATCH failed` warnings for #133 / #136.
- [ ] Run log shows `CR-133: issue closed — reconciling cr_tasks row to cancelled` (info line).
- [ ] Subsequent watchdog run finds zero pending+auto-execute rows for #133 / #136 (rows now `done`, query returns nothing).
- [ ] Issue #133 / #136 still receive zero new bot comments.

## Out of scope

Other workflows write status values not in the CHECK enum:
- `cr-intake.yml:495` writes `status='investigating'`
- `cr-intake.yml:601` writes `status='needs-clarification'`
- `cr-manual-closeout.yml:73` writes `status='in-progress'`

These are likely silently failing for the same reason. Worth a separate CR to either (a) extend the CHECK constraint to include them, or (b) replace with allowed values. Not addressed here to keep the CR-146 scope minimum-viable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)