### PR TITLE
fix(cr-155): hide dog field in Dog Blog Story Studio editor

### DIFF
--- a/sanity/schemaTypes/successStory.ts
+++ b/sanity/schemaTypes/successStory.ts
@@ -6,14 +6,6 @@ export const successStory = defineType({
   type: 'document',
   fields: [
     defineField({
-      name: 'dog',
-      title: 'Dog',
-      type: 'reference',
-      to: [{ type: 'dog' }],
-      validation: (Rule) => Rule.required(),
-      description: 'Select the adopted dog this story is about',
-    }),
-    defineField({
       name: 'title',
       title: 'Story Title',
       type: 'string',
@@ -82,13 +74,11 @@ export const successStory = defineType({
   preview: {
     select: {
       title: 'title',
-      dogName: 'dog.name',
       media: 'featuredImage',
     },
-    prepare({ title, dogName, media }) {
+    prepare({ title, media }) {
       return {
         title: title || 'Untitled',
-        subtitle: dogName ? `About ${dogName}` : '',
         media,
       }
     },

--- a/sanity/schemaTypes/successStory.ts
+++ b/sanity/schemaTypes/successStory.ts
@@ -6,6 +6,14 @@ export const successStory = defineType({
   type: 'document',
   fields: [
     defineField({
+      name: 'dog',
+      title: 'Dog',
+      type: 'reference',
+      to: [{ type: 'dog' }],
+      hidden: true,
+      description: 'Select the adopted dog this story is about',
+    }),
+    defineField({
       name: 'title',
       title: 'Story Title',
       type: 'string',
@@ -74,11 +82,13 @@ export const successStory = defineType({
   preview: {
     select: {
       title: 'title',
+      dogName: 'dog.name',
       media: 'featuredImage',
     },
-    prepare({ title, media }) {
+    prepare({ title, dogName, media }) {
       return {
         title: title || 'Untitled',
+        subtitle: dogName ? `About ${dogName}` : '',
         media,
       }
     },


### PR DESCRIPTION
## Summary

- Resolves CR-155. Hides the `dog` reference field from the Sanity Studio editor for Dog Blog Stories (`successStory` schema). Lori reported the required Dog field was blocking stories not tied to a specific dog in rescue.
- Initial commit on this branch (`16dc26d`) over-scoped by deleting the schema field entirely. Corrected by follow-up commit (`9e15596`).
- Final net diff vs `main` is **one line**: `validation: (Rule) => Rule.required()` → `hidden: true`.

## Files changed

`sanity/schemaTypes/successStory.ts`:

```diff
       title: 'Dog',
       type: 'reference',
       to: [{ type: 'dog' }],
-      validation: (Rule) => Rule.required(),
+      hidden: true,
       description: 'Select the adopted dog this story is about',
```

Everything else in the schema (preview block, all other fields) is unchanged from `main`.

## Behavior

- **Editor UI:** Dog field is hidden in the Dog Blog Story editor. Lori can save stories without picking a dog.
- **Schema declaration:** Intact (`name: 'dog'` still declared).
- **Existing data:** Untouched — legacy stories that already have a `dog` reference retain that data.
- **GROQ readability:** Unchanged. The preview block's `dogName: 'dog.name'` projection continues to work, so legacy stories still show the "About `<name>`" subtitle in Studio list view.
- **TS types:** Unchanged — the field is still part of the schema type.

## Test plan

- [x] `npx tsc --noEmit` passes (`.next/types` cleared first).
- [x] Local dev server compiles the Studio.
  - `GET /studio` → 200
  - `GET /studio/structure` → 200
- [x] Frontend regression — `GET /the-dog-blog` → 200.
- [x] No schema-compile warnings/errors in dev log.
- [ ] Vercel preview — confirm Studio loads, open a Dog Blog Story doc, confirm Dog field is no longer visible.
- [ ] Post-merge — Lori confirms she can create a new Dog Blog Story without a dog reference.

## Commit history on this branch

- `16dc26d` — initial (over-scoped: deleted the field). Superseded.
- `9e15596` — correction: hide field, keep schema declaration.

If single-commit history is preferred, rebase/squash on merge (the PR is small enough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)