### PR TITLE
feat(cr-157): home "Meet Some of Our Available Danes" + See all CTA

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -117,7 +117,15 @@ export default async function Home() {
       {/* Featured Dogs */}
       <section className="bg-gradient-to-b from-white to-slate-50 py-20">
         <div className="max-w-7xl mx-auto px-4">
-          <h2 className="text-3xl font-bold text-center text-gray-900 mb-12">Meet Our Available Danes</h2>
+          <h2 className="text-3xl font-bold text-center text-gray-900 mb-6">Meet Some of Our Available Danes</h2>
+          <div className="flex justify-center mb-12">
+            <Link
+              href="/available-danes"
+              className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white px-6 py-3 rounded-lg font-semibold transition-all"
+            >
+              See all Danes →
+            </Link>
+          </div>
           {featured.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
               {featured.map((dog) => (


### PR DESCRIPTION
## Summary

Resolves CR-157. Lori reported visitors think the 4 featured Danes on the home page are the only ones in rescue. Two content tweaks in the Featured Dogs section:

1. Heading text: **"Meet Our Available Danes"** → **"Meet Some of Our Available Danes"**.
2. Add a **"See all Danes →"** button (links to `/available-danes`) directly below the heading, above the 4-dog grid. Per Ray's placement choice on review.

## Files changed

`src/app/(main)/page.tsx` — single-section edit in the Featured Dogs block. Button uses the existing emerald CTA styling already in the file (`bg-emerald-500 hover:bg-emerald-600 ... px-6 py-3`).

## Visual order

```
Meet Some of Our Available Danes

      [ See all Danes → ]

[Dog 1]  [Dog 2]  [Dog 3]  [Dog 4]
```

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] Local dev — `GET /` → 200; rendered HTML has heading → button → grid in correct DOM order; button href = `/available-danes`.
- [ ] Vercel preview — visual check + button click navigates to `/available-danes`.
- [ ] Post-merge production smoke on `rmgreatdane.org`.

## Out of scope

- No changes to `/available-danes` page itself.
- No copy changes elsewhere on the home page.
- No restructuring of the Featured Dogs section (grid layout, dog cards, empty state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)